### PR TITLE
Update Release to 1.2.0 After October Audit Changes

### DIFF
--- a/src/enforcers/ERC721TransferEnforcer.sol
+++ b/src/enforcers/ERC721TransferEnforcer.sol
@@ -33,7 +33,6 @@ contract ERC721TransferEnforcer is CaveatEnforcer {
     {
         (address permittedContract_, uint256 permittedTokenId_) = getTermsInfo(_terms);
         (address target_,, bytes calldata callData_) = ExecutionLib.decodeSingle(_executionCallData);
-        bytes4 selector_ = bytes4(callData_[0:4]);
 
         // Decode the remaining callData into NFT transfer parameters
         // The calldata should be at least 100 bytes (4 bytes for the selector + 96 bytes for the parameters)
@@ -47,6 +46,8 @@ contract ERC721TransferEnforcer is CaveatEnforcer {
         if (from_ == address(0) || to_ == address(0)) {
             revert("ERC721TransferEnforcer:invalid-address");
         }
+
+        bytes4 selector_ = bytes4(callData_[0:4]);
 
         if (target_ != permittedContract_) {
             revert("ERC721TransferEnforcer:unauthorized-contract-target");

--- a/src/enforcers/OwnershipTransferEnforcer.sol
+++ b/src/enforcers/OwnershipTransferEnforcer.sol
@@ -72,10 +72,11 @@ contract OwnershipTransferEnforcer is CaveatEnforcer {
         returns (address newOwner_)
     {
         (address target_,, bytes calldata callData_) = _executionCallData.decodeSingle();
-        bytes4 selector = bytes4(callData_[0:4]);
-        require(selector == IERC173.transferOwnership.selector, "OwnershipTransferEnforcer:invalid-method");
 
         require(callData_.length == 36, "OwnershipTransferEnforcer:invalid-execution-length");
+
+        bytes4 selector_ = bytes4(callData_[0:4]);
+        require(selector_ == IERC173.transferOwnership.selector, "OwnershipTransferEnforcer:invalid-method");
 
         address targetContract_ = getTermsInfo(_terms);
         require(targetContract_ == target_, "OwnershipTransferEnforcer:invalid-contract");

--- a/test/enforcers/OwnershipTransferEnforcer.t.sol
+++ b/test/enforcers/OwnershipTransferEnforcer.t.sol
@@ -90,8 +90,11 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
     // Reverts if the method called is not transferOwnership
     function test_notAllow_invalidMethod() public {
         bytes memory terms_ = abi.encodePacked(mockContract);
-        transferOwnershipExecution =
-            Execution({ target: mockContract, value: 0, callData: abi.encodeWithSelector(bytes4(keccak256("someOtherMethod()"))) });
+        transferOwnershipExecution = Execution({
+            target: mockContract,
+            value: 0,
+            callData: abi.encodeWithSelector(bytes4(keccak256("someOtherMethod(address)")), address(0))
+        });
         transferOwnershipExecutionCallData = ExecutionLib.encodeSingle(
             transferOwnershipExecution.target, transferOwnershipExecution.value, transferOwnershipExecution.callData
         );


### PR DESCRIPTION
### **What?**

- October Audit 3.2 Selector and Calldata Length (#463)

### **Why?**

- It was prone to errors when the calldata was not long enough

### **How?**

- Moved the selector after the calldata length validation
