### PR TITLE
Github Actions Point to Stable Foundry Version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Foundry
         uses: MetaMask/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge Install
         run: forge install


### PR DESCRIPTION
### **What?**

- The github actions was previously running the tests and validation contract size using the foundry version nightly, but it is recommended by foundry to use the stable version.

### **Why?**

- 
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/cbe684c0-b4b7-48c4-8a94-301cbfe1f8c1" />


### **How?**

- Changing the version in the github actions
