### PR TITLE
Added EIP7702 stateless and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,35 @@ forge test
 
 #### Deploying
 
-0. Copy `.env.example` to `.env` and populate the variables you plan to use if you plan to deploy any contracts.
+1. Copy `.env.example` to `.env` and populate the variables depending on the deployment scripts that you will execute.
 
 ```shell
 source .env
 ```
 
-1. Use [Anvil](https://book.getfoundry.sh/reference/anvil/) to run a local fork of a blockchain to develop in an isolated environment.
+2. For local testing, use [Anvil](https://book.getfoundry.sh/reference/anvil/) to run a local fork of a blockchain to develop in an isolated environment. Or obtain the RPC url for the blockchain to deploy.
 
 ```shell
+# Example of a forked local environment using anvil
 anvil -f <your_rpc_url>
 ```
 
-2. Deploy the necessary environment contracts.
+3. Deploy the necessary contracts.
 
 > NOTE: As this system matures, this step will no longer be required for public chains where the DeleGator is in use.
 
 ```shell
-forge script script/DeployEnvironmentSetUp.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+# Deploys the Delegation Manager, Multisig and Hybrid DeleGator implementations
+forge script script/DeployDelegationFramework.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+
+# Deploys all the caveat enforcers
+forge script script/DeployCaveatEnforcers.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+
+# Deploys the EIP7702 Staless DeleGator
+forge script script/DeployEIP7702StatelessDeleGator.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+
+# Deploys a MultisigDeleGator on a UUPS proxy
+forge script script/DeployMultiSigDeleGator.s.sol --private-key $PRIVATE_KEY --broadcast
 ```
 
 ### Javascript
@@ -143,3 +154,5 @@ Currently in Gated Alpha phase. Sign up to be an early partner [here](https://ga
 - [EIP-7201](https://eips.ethereum.org/EIPS/eip-7201)
 - [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212)
 - [EIP-7579](https://eips.ethereum.org/EIPS/eip-7579)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)
+- [EIP-7821](https://eips.ethereum.org/EIPS/eip-7821)

--- a/documents/EIP7702DeleGator.md
+++ b/documents/EIP7702DeleGator.md
@@ -1,0 +1,23 @@
+# EIP-7702 Smart Contracts
+
+## Overview
+
+This document provides an overview of the implemented EIP-7702-compatible contracts. These contracts use a different upgrade mechanism than the previous UUPS proxy-based architecture (as implemented in DeleGatorCore) and instead follow the EIP-7702 standard.
+
+Under EIP-7702, an Externally Owned Account (EOA) can submit an authorization to map the contract code of an existing contract to that EOA. Unlike UUPS proxy-based contracts, this approach neither supports contract initialization nor relies on UUPS-related code.
+
+## Contracts
+
+### 1. EIP7702DeleGatorCore.sol
+
+**EIP7702DeleGatorCore** serves as the foundational contract for EIP-7702-compatible delegator functionality with ERC-7710. It acts as the primary interface for interactions under EIP-7702 and implements the EIP-7821 interface, which provides a method to execute calls in different modes (e.g., single or batch). These methods can be invoked either through the privileged ERC-4337 EntryPoint or directly via the EOA address.
+
+Future implementations may introduce additional features, such as signature validation, as outlined in EIP-7821.
+
+This contract also integrates OpenZeppelin’s EIP712 functionality. The name and version used in the EIP712 constructor are limited to a maximum of 31 bytes. Exceeding this limit causes those variables to be stored in the contract state without namespace storage, leading to conflicts. Restricting the name and version size helps ensure that **EIP7702DeleGatorCore** remains stateless by avoiding additional storage.
+
+### 2. EIP7702StatelessDeleGator.sol
+
+**EIP7702StatelessDeleGator** does not maintain signer data within the contract state. Instead, control is granted to the EOA that shares the same address, in accordance with EIP-7702. The contract can be invoked either through the privileged ERC-4337 EntryPoint or directly via the EOA address. The signature is verified via the `isValidSignature()` function.
+
+This stateless design offers a lightweight and secure approach to delegator functionality under the EIP-7702 standard.

--- a/script/DeployEIP7702StatelessDeleGator.s.sol
+++ b/script/DeployEIP7702StatelessDeleGator.s.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";
+
+import { EIP7702StatelessDeleGator } from "../src/EIP7702/EIP7702StatelessDeleGator.sol";
+import { IDelegationManager } from "../src/interfaces/IDelegationManager.sol";
+
+/**
+ * @title DeployEIP7702StatelessDeleGator.s.sol
+ * @notice Deploys the required contracts for the EIP7702 StatelessDeleGator to function.
+ * @dev These contracts are likely already deployed on a testnet or mainnet as many are singletons.
+ * @dev run the script with:
+ * forge script script/DeployEIP7702StatelessDeleGator.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+ */
+contract DeployEIP7702StatelessDeleGator is Script {
+    bytes32 salt;
+    IEntryPoint entryPoint;
+    IDelegationManager delegationManager;
+    address deployer;
+
+    function setUp() public {
+        salt = bytes32(abi.encodePacked(vm.envString("SALT")));
+        entryPoint = IEntryPoint(vm.envAddress("ENTRYPOINT_ADDRESS"));
+        delegationManager = IDelegationManager(vm.envAddress("DELEGATION_MANAGER_ADDRESS"));
+        deployer = msg.sender;
+        console2.log("~~~");
+        console2.log("Deployer: %s", address(deployer));
+        console2.log("Entry Point: %s", address(entryPoint));
+        console2.log("Delegation Manager: %s", address(delegationManager));
+        console2.log("Salt:");
+        console2.logBytes32(salt);
+    }
+
+    function run() public {
+        console2.log("~~~");
+        vm.startBroadcast();
+
+        address deployedAddress;
+
+        // Deploy EIP7702StatelessDeleGator
+
+        deployedAddress = address(new EIP7702StatelessDeleGator{ salt: salt }(IDelegationManager(delegationManager), entryPoint));
+        console2.log("EIP7702StatelessDeleGatorImpl: %s", deployedAddress);
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/EIP7702/EIP7702DeleGatorCore.sol
+++ b/src/EIP7702/EIP7702DeleGatorCore.sol
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { IERC1155Receiver } from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ExecutionHelper } from "@erc7579/core/ExecutionHelper.sol";
+import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { ERC1271Lib } from "../libraries/ERC1271Lib.sol";
+import { IDeleGatorCore } from "../interfaces/IDeleGatorCore.sol";
+import { IDelegationManager } from "../interfaces/IDelegationManager.sol";
+import { IERC7821 } from "../interfaces/IERC7821.sol";
+import {
+    CallType, ExecType, ModeSelector, ModePayload, Execution, Delegation, PackedUserOperation, ModeCode
+} from "../utils/Types.sol";
+import { CALLTYPE_SINGLE, CALLTYPE_BATCH, EXECTYPE_DEFAULT, EXECTYPE_TRY, MODE_DEFAULT } from "../utils/Constants.sol";
+
+/**
+ * @title EIP7702DeleGatorCore
+ * @notice This contract contains the shared logic for a DeleGator SCA implementation.
+ * @dev Implements the interface needed for a DelegationManager to interact with a DeleGator implementation.
+ * @dev DeleGator implementations can inherit this to enable Delegation and ERC4337 structure.
+ * @dev Any child contract adding state variables must use namespaced storage for safe upgrades.
+ */
+abstract contract EIP7702DeleGatorCore is
+    ExecutionHelper,
+    IERC165,
+    IERC7821,
+    IDeleGatorCore,
+    IERC721Receiver,
+    IERC1155Receiver,
+    EIP712
+{
+    using ModeLib for ModeCode;
+    using ModeLib for ModeSelector;
+    using ExecutionLib for bytes;
+
+    ////////////////////////////// State //////////////////////////////
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address private immutable __self = address(this);
+
+    /// @dev The DelegationManager contract that has root access to this contract
+    IDelegationManager public immutable delegationManager;
+
+    /// @dev The EntryPoint contract that has root access to this contract
+    IEntryPoint public immutable entryPoint;
+
+    /// @dev The typehash for the PackedUserOperation struct
+    bytes32 public constant PACKED_USER_OP_TYPEHASH = keccak256(
+        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)"
+    );
+
+    ////////////////////////////// Events //////////////////////////////
+
+    /// @dev Emitted once in the constructor when the DelegationManager is assigned
+    event SetDelegationManager(IDelegationManager indexed newDelegationManager);
+
+    /// @dev Emitted once in the constructor when the EntryPoint is assigned
+    event SetEntryPoint(IEntryPoint indexed entryPoint);
+
+    /// @dev Event emitted when prefunding is sent.
+    event SentPrefund(address indexed sender, uint256 amount, bool success);
+
+    ////////////////////////////// Errors //////////////////////////////
+
+    /// @dev Error thrown when the caller is not this contract.
+    error NotSelf();
+
+    /// @dev Error thrown when the caller is not the entry point.
+    error NotEntryPoint();
+
+    /// @dev Error thrown when the caller is not the EntryPoint or this contract.
+    error NotEntryPointOrSelf();
+
+    /// @dev Error thrown when the caller is not the delegation manager.
+    error NotDelegationManager();
+
+    /// @dev The call is from an unauthorized context.
+    error UnauthorizedCallContext();
+
+    /// @dev Error thrown when an execution with an unsupported CallType was made.
+    error UnsupportedCallType(CallType callType);
+
+    /// @dev Error thrown when an execution with an unsupported ExecType was made.
+    error UnsupportedExecType(ExecType execType);
+
+    /// @dev The EIP712 name can not be longer than 31 bytes.
+    error InvalidEIP712NameLength();
+
+    /// @dev The EIP712 version can not be longer than 31 bytes.
+    error InvalidEIP712VersionLength();
+
+    ////////////////////////////// Modifiers //////////////////////////////
+
+    /**
+     * @dev Prevents direct calls to the implementation.
+     * @dev Check that the execution is being performed through a delegatecall call.
+     */
+    modifier onlyProxy() {
+        if (address(this) == __self) revert UnauthorizedCallContext();
+        _;
+    }
+
+    /**
+     * @notice Require the function call to come from the EntryPoint.
+     * @dev Check that the caller is the entry point
+     */
+    modifier onlyEntryPoint() {
+        if (msg.sender != address(entryPoint)) revert NotEntryPoint();
+        _;
+    }
+
+    /**
+     * @notice Require the function call to come from the EntryPoint or this contract.
+     * @dev Check that the caller is either the delegator contract itself or the entry point
+     */
+    modifier onlyEntryPointOrSelf() {
+        if (msg.sender != address(entryPoint) && msg.sender != address(this)) revert NotEntryPointOrSelf();
+        _;
+    }
+
+    /**
+     * @notice Require the function call to come from the DelegationManager.
+     * @dev Check that the caller is the stored delegation manager.
+     */
+    modifier onlyDelegationManager() {
+        if (msg.sender != address(delegationManager)) revert NotDelegationManager();
+        _;
+    }
+
+    ////////////////////////////// Constructor //////////////////////////////
+
+    /**
+     * @notice Initializes the DeleGatorCore contract
+     * @param _delegationManager the address of the trusted DelegationManager contract that will have root access to this contract
+     * @param _entryPoint the address of entry point
+     * @param _name Name of the contract
+     * @param _domainVersion Domain version of the contract
+     */
+    constructor(
+        IDelegationManager _delegationManager,
+        IEntryPoint _entryPoint,
+        string memory _name,
+        string memory _domainVersion
+    )
+        EIP712(_name, _domainVersion)
+    {
+        // Short name and version do not use storage in EIP712
+        if (bytes(_name).length > 31) revert InvalidEIP712NameLength();
+        if (bytes(_domainVersion).length > 31) revert InvalidEIP712VersionLength();
+
+        delegationManager = _delegationManager;
+        entryPoint = _entryPoint;
+        emit SetDelegationManager(_delegationManager);
+        emit SetEntryPoint(_entryPoint);
+    }
+
+    ////////////////////////////// External Methods //////////////////////////////
+
+    /**
+     * @notice Allows this contract to receive the chains native token
+     */
+    receive() external payable { }
+
+    /**
+     * @notice Redeems a delegation on the DelegationManager and executes the specified executions on behalf of the root delegator.
+     * @param _permissionContexts An array of bytes where each element is made up of an array
+     * of `Delegation` structs that are used to validate the authority given to execute the corresponding execution on the
+     * root delegator, ordered from leaf to root.
+     * @param _modes An array of `ModeCode` structs representing the mode of execution for each execution callData.
+     * @param _executionCallDatas An array of `Execution` structs representing the executions to be executed.
+     */
+    function redeemDelegations(
+        bytes[] calldata _permissionContexts,
+        ModeCode[] calldata _modes,
+        bytes[] calldata _executionCallDatas
+    )
+        external
+        onlyEntryPointOrSelf
+    {
+        delegationManager.redeemDelegations(_permissionContexts, _modes, _executionCallDatas);
+    }
+
+    /**
+     * @notice Executes an Execution from this contract
+     * @dev This method is intended to be called through a UserOp which ensures the invoker has sufficient permissions
+     * @dev This convenience method defaults to reverting on failure and a single execution.
+     * @param _execution The Execution to be executed
+     */
+    function execute(Execution calldata _execution) external payable onlyEntryPointOrSelf {
+        _execute(_execution.target, _execution.value, _execution.callData);
+    }
+
+    /**
+     * @notice Executes an Execution from this contract
+     * @dev Related: @erc7579/MSAAdvanced.sol and ERC-7821
+     * @dev This method must be called from the entry point or self
+     * @param _mode The ModeCode for the execution
+     * @param _executionCalldata The calldata for the execution
+     */
+    function execute(ModeCode _mode, bytes calldata _executionCalldata) external payable onlyEntryPointOrSelf {
+        (CallType callType_, ExecType execType_,,) = _mode.decode();
+
+        // Check if calltype is batch or single
+        if (callType_ == CALLTYPE_BATCH) {
+            // destructure executionCallData according to batched exec
+            Execution[] calldata executions_ = _executionCalldata.decodeBatch();
+            // Check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) _execute(executions_);
+            else if (execType_ == EXECTYPE_TRY) _tryExecute(executions_);
+            else revert UnsupportedExecType(execType_);
+        } else if (callType_ == CALLTYPE_SINGLE) {
+            // Destructure executionCallData according to single exec
+            (address target_, uint256 value_, bytes calldata callData_) = _executionCalldata.decodeSingle();
+            // Check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) {
+                _execute(target_, value_, callData_);
+            } else if (execType_ == EXECTYPE_TRY) {
+                bytes[] memory returnData_ = new bytes[](1);
+                bool success_;
+                (success_, returnData_[0]) = _tryExecute(target_, value_, callData_);
+                if (!success_) emit TryExecuteUnsuccessful(0, returnData_[0]);
+            } else {
+                revert UnsupportedExecType(execType_);
+            }
+        } else {
+            revert UnsupportedCallType(callType_);
+        }
+    }
+
+    /**
+     * @inheritdoc IDeleGatorCore
+     * @dev Related: @erc7579/MSAAdvanced.sol
+     */
+    function executeFromExecutor(
+        ModeCode _mode,
+        bytes calldata _executionCalldata
+    )
+        external
+        payable
+        onlyDelegationManager
+        returns (bytes[] memory returnData_)
+    {
+        (CallType callType_, ExecType execType_,,) = _mode.decode();
+
+        // Check if calltype is batch or single
+        if (callType_ == CALLTYPE_BATCH) {
+            // Destructure executionCallData according to batched exec
+            Execution[] calldata executions_ = _executionCalldata.decodeBatch();
+            // check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) returnData_ = _execute(executions_);
+            else if (execType_ == EXECTYPE_TRY) returnData_ = _tryExecute(executions_);
+            else revert UnsupportedExecType(execType_);
+        } else if (callType_ == CALLTYPE_SINGLE) {
+            // Destructure executionCallData according to single exec
+            (address target_, uint256 value_, bytes calldata callData_) = _executionCalldata.decodeSingle();
+            returnData_ = new bytes[](1);
+            bool success_;
+            // check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) {
+                returnData_[0] = _execute(target_, value_, callData_);
+            } else if (execType_ == EXECTYPE_TRY) {
+                (success_, returnData_[0]) = _tryExecute(target_, value_, callData_);
+                if (!success_) emit TryExecuteUnsuccessful(0, returnData_[0]);
+            } else {
+                revert UnsupportedExecType(execType_);
+            }
+        } else {
+            revert UnsupportedCallType(callType_);
+        }
+    }
+
+    /**
+     * @notice Validates a UserOp signature and sends any necessary funds to the EntryPoint
+     * @dev Related: ERC4337
+     * @param _userOp The UserOp struct to validate
+     * @param _missingAccountFunds The missing funds from the account
+     * @return validationData_ The validation data
+     */
+    function validateUserOp(
+        PackedUserOperation calldata _userOp,
+        bytes32, // Ignore UserOpHash from the Entry Point
+        uint256 _missingAccountFunds
+    )
+        external
+        onlyEntryPoint
+        onlyProxy
+        returns (uint256 validationData_)
+    {
+        validationData_ = _validateUserOpSignature(_userOp, getPackedUserOperationTypedDataHash(_userOp));
+        _payPrefund(_missingAccountFunds);
+    }
+
+    /**
+     * @inheritdoc IERC1271
+     * @notice Verifies the signatures of the signers.
+     * @dev Related: ERC4337, Delegation
+     * @param _hash The hash of the data signed.
+     * @param _signature The signatures of the signers.
+     * @return magicValue_ A bytes4 magic value which is EIP1271_MAGIC_VALUE(0x1626ba7e) if the signature is valid, returns
+     * SIG_VALIDATION_FAILED(0xffffffff) if there is a signature mismatch and reverts (for all other errors).
+     */
+    function isValidSignature(
+        bytes32 _hash,
+        bytes calldata _signature
+    )
+        external
+        view
+        override
+        onlyProxy
+        returns (bytes4 magicValue_)
+    {
+        return _isValidSignature(_hash, _signature);
+    }
+
+    /// @inheritdoc IERC721Receiver
+    function onERC721Received(address, address, uint256, bytes memory) external view override onlyProxy returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    /// @inheritdoc IERC1155Receiver
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    )
+        external
+        view
+        override
+        onlyProxy
+        returns (bytes4)
+    {
+        return this.onERC1155Received.selector;
+    }
+
+    /// @inheritdoc IERC1155Receiver
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] memory,
+        uint256[] memory,
+        bytes memory
+    )
+        external
+        view
+        override
+        onlyProxy
+        returns (bytes4)
+    {
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    /**
+     * @notice Deposits more funds for this account in the entry point
+     * @dev Related: ERC4337
+     */
+    function addDeposit() external payable onlyProxy {
+        entryPoint.depositTo{ value: msg.value }(address(this));
+    }
+
+    /**
+     * @notice This method withdraws funds of this account from the entry point
+     * @dev Related: ERC4337
+     * @param _withdrawAddress Address to withdraw the amount to
+     * @param _withdrawAmount Amount to be withdraw from the entry point
+     */
+    function withdrawDeposit(address payable _withdrawAddress, uint256 _withdrawAmount) external onlyEntryPointOrSelf {
+        entryPoint.withdrawTo(_withdrawAddress, _withdrawAmount);
+    }
+
+    /**
+     * @notice Disables a delegation from being used
+     * @param _delegation The delegation to be disabled
+     */
+    function disableDelegation(Delegation calldata _delegation) external onlyEntryPointOrSelf {
+        delegationManager.disableDelegation(_delegation);
+    }
+
+    /**
+     * @notice Enables a delegation to be used
+     * @dev Delegations only need to be enabled if they have been disabled
+     * @param _delegation The delegation to be enabled
+     */
+    function enableDelegation(Delegation calldata _delegation) external onlyEntryPointOrSelf {
+        delegationManager.enableDelegation(_delegation);
+    }
+
+    /**
+     * @notice Checks if the delegation is disabled
+     * @param _delegationHash the hash of the delegation to check for disabled status.
+     * @return bool is the delegation disabled
+     */
+    function isDelegationDisabled(bytes32 _delegationHash) external view returns (bool) {
+        return delegationManager.disabledDelegations(_delegationHash);
+    }
+
+    /**
+     * @notice Gets the current account's deposit in the entry point
+     * @dev Related: ERC4337
+     * @return uint256 The current account's deposit in the entry point
+     */
+    function getDeposit() external view returns (uint256) {
+        return entryPoint.balanceOf(address(this));
+    }
+
+    /**
+     * @notice Returns the next sequential nonce using a static key
+     * @dev Related: ERC4337
+     * @return uint256 The next sequential nonce
+     */
+    function getNonce() external view returns (uint256) {
+        return entryPoint.getNonce(address(this), 0);
+    }
+
+    /**
+     * @notice Returns the next sequential nonce using a custom key
+     * @dev Related: ERC4337
+     * @return uint256 The next sequential nonce for the key provided
+     * @param _key The key to use for the nonce
+     */
+    function getNonce(uint192 _key) external view returns (uint256) {
+        return entryPoint.getNonce(address(this), _key);
+    }
+
+    /**
+     * @notice This method returns the domain hash used for signing typed data
+     * @return bytes32 The domain hash
+     */
+    function getDomainHash() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    /**
+     * @notice Returns a boolean indicating if a mode is supported
+     * @param _mode The mode to validate
+     * @notice Returns true if the mode is supported, and false otherwise
+     */
+    function supportsExecutionMode(ModeCode _mode) external view virtual override returns (bool) {
+        (CallType callType_, ExecType execType_, ModeSelector modeSelector_, ModePayload modePayload_) = _mode.decode();
+
+        return (
+            (callType_ == CALLTYPE_SINGLE || callType_ == CALLTYPE_BATCH)
+                && (execType_ == EXECTYPE_DEFAULT || execType_ == EXECTYPE_TRY) && (modeSelector_ == MODE_DEFAULT)
+                && (ModePayload.unwrap(modePayload_) == bytes22(0x00))
+        );
+    }
+
+    /**
+     * @notice Returns the formatted hash to sign for an EIP712 typed data signature
+     * @param _userOp the UserOp to hash
+     * @notice Returns an EIP712 typed data hash for a given UserOp
+     */
+    function getPackedUserOperationTypedDataHash(PackedUserOperation calldata _userOp) public view returns (bytes32) {
+        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), getPackedUserOperationHash(_userOp));
+    }
+
+    /**
+     * @inheritdoc IERC165
+     * @dev Supports the following interfaces: IDeleGatorCore, IERC721Receiver, IERC1155Receiver, IERC165, IERC1271
+     */
+    function supportsInterface(bytes4 _interfaceId) public view virtual override(IERC165) onlyProxy returns (bool) {
+        return _interfaceId == type(IDeleGatorCore).interfaceId || _interfaceId == type(IERC721Receiver).interfaceId
+            || _interfaceId == type(IERC1155Receiver).interfaceId || _interfaceId == type(IERC165).interfaceId
+            || _interfaceId == type(IERC1271).interfaceId || _interfaceId == type(IERC7821).interfaceId;
+    }
+
+    /**
+     * Provides the typed data hash for a PackedUserOperation
+     * @param _userOp the PackedUserOperation to hash
+     */
+    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                PACKED_USER_OP_TYPEHASH,
+                _userOp.sender,
+                _userOp.nonce,
+                keccak256(_userOp.initCode),
+                keccak256(_userOp.callData),
+                _userOp.accountGasLimits,
+                _userOp.preVerificationGas,
+                _userOp.gasFees,
+                keccak256(_userOp.paymasterAndData)
+            )
+        );
+    }
+
+    ////////////////////////////// Internal Methods //////////////////////////////
+
+    /**
+     * @notice Sends the entrypoint (msg.sender) any needed funds for the transaction.
+     * @param _missingAccountFunds the minimum value this method should send the entrypoint.
+     *         this value MAY be zero, in case there is enough deposit, or the userOp has a paymaster.
+     */
+    function _payPrefund(uint256 _missingAccountFunds) internal {
+        if (_missingAccountFunds != 0) {
+            (bool success_,) = payable(msg.sender).call{ value: _missingAccountFunds, gas: type(uint256).max }("");
+            (success_);
+            // Ignore failure (it's EntryPoint's job to verify, not account.)
+            emit SentPrefund(msg.sender, _missingAccountFunds, success_);
+        }
+    }
+
+    /**
+     * @notice The logic to verify if the signature is valid for this contract
+     * @dev This is an internal function that should be overridden by the implementing contract based on the signature scheme used.
+     * @dev Related: ERC4337
+     * @param _hash The hash of the data signed.
+     * @param _signature The signatures of the signers.
+     * @return A bytes4 magic value which is EIP1271_MAGIC_VALUE(0x1626ba7e) if the signature is valid, returns
+     * SIG_VALIDATION_FAILED(0xffffffff) if there is a signature mismatch and reverts (for all other errors).
+     */
+    function _isValidSignature(bytes32 _hash, bytes calldata _signature) internal view virtual returns (bytes4);
+
+    /**
+     * @notice Validates a UserOp signature and returns a code indicating if the signature is valid or not
+     * @dev This method calls the DeleGator implementations `_isValidSignature` to validate the signature according to the
+     * implementations auth scheme.
+     * @dev Returns 0 if the signature is valid, 1 if the signature is invalid.
+     * @dev Related: ERC4337
+     * @param _userOp The UserOp
+     * @param _userOpHash UserOp hash produced with typed data
+     * @return validationData_ A code indicating if the signature is valid or not
+     */
+    function _validateUserOpSignature(
+        PackedUserOperation calldata _userOp,
+        bytes32 _userOpHash
+    )
+        internal
+        view
+        returns (uint256 validationData_)
+    {
+        bytes4 result_ = _isValidSignature(_userOpHash, _userOp.signature);
+        if (result_ == ERC1271Lib.EIP1271_MAGIC_VALUE) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/src/EIP7702/EIP7702StatelessDeleGator.sol
+++ b/src/EIP7702/EIP7702StatelessDeleGator.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";
+
+import { EIP7702DeleGatorCore } from "./EIP7702DeleGatorCore.sol";
+import { IDelegationManager } from "../interfaces/IDelegationManager.sol";
+import { ERC1271Lib } from "../libraries/ERC1271Lib.sol";
+
+/**
+ * @title EIP7702 Stateless Delegator Contract
+ * @dev This contract extends the EIP7702DeleGatorCore contract. It provides functionality for EIP7702 based access control
+ * and delegation.
+ * @dev The signer that controls the DeleGator MUST be the EIP7702 EOA
+ */
+contract EIP7702StatelessDeleGator is EIP7702DeleGatorCore {
+    ////////////////////////////// State //////////////////////////////
+
+    /// @dev The name of the contract
+    string public constant NAME = "EIP7702StatelessDeleGator";
+
+    /// @dev The version used in the domainSeparator for EIP712
+    string public constant DOMAIN_VERSION = "1";
+
+    /// @dev The version of the contract
+    string public constant VERSION = "1.3.0";
+
+    /// @dev The length of a signature
+    uint256 private constant SIGNATURE_LENGTH = 65;
+
+    ////////////////////////////// Constructor //////////////////////////////
+
+    /**
+     * @notice Constructor for the EIP7702Stateless DeleGator
+     * @param _delegationManager the address of the trusted DelegationManager contract that will have root access to this contract
+     * @param _entryPoint the address of the EntryPoint contract that will have root access to this contract
+     */
+    constructor(
+        IDelegationManager _delegationManager,
+        IEntryPoint _entryPoint
+    )
+        EIP7702DeleGatorCore(_delegationManager, _entryPoint, NAME, DOMAIN_VERSION)
+    { }
+
+    ////////////////////////////// Internal Methods //////////////////////////////
+
+    /**
+     * @notice This method is used to verify the signature of the signer
+     * @param _hash The data signed
+     * @param _signature A 65-byte signature produced by the EIP7702 EOA
+     * @return The EIP1271 magic value if the signature is valid, otherwise it reverts
+     */
+    function _isValidSignature(bytes32 _hash, bytes calldata _signature) internal view override returns (bytes4) {
+        if (_signature.length != SIGNATURE_LENGTH) return ERC1271Lib.SIG_VALIDATION_FAILED;
+
+        if (ECDSA.recover(_hash, _signature) == address(this)) return ERC1271Lib.EIP1271_MAGIC_VALUE;
+
+        return ERC1271Lib.SIG_VALIDATION_FAILED;
+    }
+}

--- a/src/interfaces/IERC7821.sol
+++ b/src/interfaces/IERC7821.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { ModeCode } from "../utils/Types.sol";
+
+/**
+ * @dev Interface for minimal batch executor.
+ */
+interface IERC7821 {
+    /**
+     * @notice Executes the function calls specified in `executionData` according to the provided `mode`.
+     *
+     * @dev The `executionData` must be encoded according to EIP-7579 standards.
+     * @param mode Execution mode as defined above.
+     * @param executionData Encoded function calls and associated data to execute.
+     * Supported modes:
+     * - `bytes32(0x0000...)`: Single execution, revert on failure.
+     * - `bytes32(0x0001...)`: Single execution, skip on failure.
+     * - `bytes32(0x0100...)`: Batch execution, revert on failure.
+     * - `bytes32(0x0101...)`: Batch execution, skip on failure.
+     *
+     */
+    function execute(ModeCode mode, bytes calldata executionData) external payable;
+
+    /**
+     * @notice Indicates whether the contract supports a given execution mode.
+     *
+     * @param mode The execution mode to check.
+     * @return bool True if the specified execution mode is supported, false otherwise.
+     *
+     * Supported modes:
+     * - `bytes32(0x0000...)`: Single execution, revert on failure.
+     * - `bytes32(0x0001...)`: Single execution, skip on failure.
+     * - `bytes32(0x0100...)`: Batch execution, revert on failure.
+     * - `bytes32(0x0101...)`: Batch execution, skip on failure.
+     */
+    function supportsExecutionMode(ModeCode mode) external view returns (bool);
+}

--- a/test/EIP7702StatelessDeleGatorTest.t.sol
+++ b/test/EIP7702StatelessDeleGatorTest.t.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IEntryPoint, EntryPoint } from "@account-abstraction/core/EntryPoint.sol";
+import { BytesLib } from "@bytes-utils/BytesLib.sol";
+import { EntryPoint } from "@account-abstraction/core/EntryPoint.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ERC1967Proxy as DeleGatorProxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { SigningUtilsLib } from "./utils/SigningUtilsLib.t.sol";
+import { Implementation, SignatureType } from "./utils/Types.t.sol";
+import { Execution, PackedUserOperation, Caveat, Delegation, ModeCode } from "../src/utils/Types.sol";
+import { BaseTest } from "./utils/BaseTest.t.sol";
+import { AccountSorterLib } from "./utils/AccountSorterLib.t.sol";
+import { EIP7702StatelessDeleGator } from "../src/EIP7702/EIP7702StatelessDeleGator.sol";
+import { IDelegationManager } from "../src/interfaces/IDelegationManager.sol";
+import { DeleGatorCore } from "../src/DeleGatorCore.sol";
+import { EncoderLib } from "../src/libraries/EncoderLib.sol";
+import { Counter } from "./utils/Counter.t.sol";
+import { UserOperationLib } from "./utils/UserOperationLib.t.sol";
+import { SimpleFactory } from "../src/utils/SimpleFactory.sol";
+import { ERC1271Lib } from "../src/libraries/ERC1271Lib.sol";
+import { EIP7702DeleGatorCore } from "../src/EIP7702/EIP7702DeleGatorCore.sol";
+import {
+    CALLTYPE_SINGLE,
+    CALLTYPE_BATCH,
+    CALLTYPE_DELEGATECALL,
+    EXECTYPE_DEFAULT,
+    EXECTYPE_TRY,
+    MODE_DEFAULT,
+    ModeLib,
+    ExecType,
+    ModeSelector,
+    ModePayload
+} from "@erc7579/lib/ModeLib.sol";
+
+/**
+ * @title EIP7702 Stateless DeleGator Implementation Test
+ * @dev These tests are for the EIP7702Stateless functionality of the EIP7702StatelessDeleGator contract.
+ * @dev NOTE: All Smart Account interactions flow through ERC4337 UserOps.
+ */
+contract EIP7702StatelessDeleGatorTest is BaseTest {
+    using MessageHashUtils for bytes32;
+
+    ////////////////////// Configure BaseTest //////////////////////
+
+    constructor() {
+        IMPLEMENTATION = Implementation.EIP7702Stateless;
+        SIGNATURE_TYPE = SignatureType.EOA;
+    }
+
+    ////////////////////////////// State //////////////////////////////
+
+    // uint256 public constant MAX_NUMBER_OF_SIGNERS = 30;
+    EIP7702StatelessDeleGator public aliceDeleGator;
+    EIP7702StatelessDeleGator public bobDeleGator;
+    Counter public aliceDeleGatorCounter;
+
+    ////////////////////// Set up //////////////////////
+
+    function setUp() public override {
+        super.setUp();
+
+        // Set up typed DeleGators
+        aliceDeleGator = EIP7702StatelessDeleGator(payable(address(users.alice.deleGator)));
+        bobDeleGator = EIP7702StatelessDeleGator(payable(address(users.bob.deleGator)));
+
+        aliceDeleGatorCounter = new Counter(address(users.alice.deleGator));
+    }
+
+    ////////////////////// Basic Functionality //////////////////////
+
+    // should allow retrieval of the account name
+    function test_allow_getName() public {
+        assertEq(aliceDeleGator.NAME(), "EIP7702StatelessDeleGator");
+    }
+
+    // should allow retrieval of the version
+    function test_allow_getVersion() public {
+        assertEq(aliceDeleGator.VERSION(), "1.3.0");
+    }
+
+    // should allow retrieval of the account name
+    function test_notAllow_toSetLongName() public {
+        string memory longName_ = "EIP7702StatelessDeleGatorName123";
+        vm.expectRevert(EIP7702DeleGatorCore.InvalidEIP712NameLength.selector);
+        new EIP7702DeleGatorTestMock(longName_, "SomeVersion");
+    }
+
+    // should allow retrieval of the version
+    function test_notAllow_toSetLongVersion() public {
+        string memory longVersion_ = "V1111111111111111111111111111111";
+        vm.expectRevert(EIP7702DeleGatorCore.InvalidEIP712VersionLength.selector);
+        new EIP7702DeleGatorTestMock("SomeName", longVersion_);
+    }
+
+    function test_emitEvent_DelegationManagerSet() public {
+        vm.expectEmit(true, true, true, true);
+        emit EIP7702DeleGatorCore.SetDelegationManager(delegationManager);
+        new EIP7702StatelessDeleGator(delegationManager, entryPoint);
+    }
+
+    function test_emitEvent_EntryPointSet() public {
+        vm.expectEmit(true, true, true, true);
+        emit EIP7702DeleGatorCore.SetEntryPoint(entryPoint);
+        new EIP7702StatelessDeleGator(delegationManager, entryPoint);
+    }
+
+    ////////////////////// Redeeming delegations //////////////////////
+
+    // should allow Bob to redeem a delegation from Alice DeleGator
+    function test_allow_invokeOffchainDelegation() public {
+        uint256 initialValue_ = aliceDeleGatorCounter.count();
+
+        // Create delegation
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: new Caveat[](0),
+            salt: 0,
+            signature: hex""
+        });
+
+        // Sign delegation
+        bytes32 delegationHash_ = EncoderLib._getDelegationHash(delegation_);
+        bytes32 domainHash_ = delegationManager.getDomainHash();
+        bytes32 typedDataHash_ = MessageHashUtils.toTypedDataHash(domainHash_, delegationHash_);
+        bytes memory signature_ = SigningUtilsLib.signHash_EOA(users.alice.privateKey, typedDataHash_);
+        delegation_.signature = signature_;
+
+        // Create Bob's execution
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+
+        // Execute Bob's UserOp
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+
+        invokeDelegation_UserOp(users.bob, delegations_, execution_);
+
+        // Get final count
+        uint256 finalValue_ = aliceDeleGatorCounter.count();
+
+        // Validate that the count has increased by 1
+        assertEq(finalValue_, initialValue_ + 1);
+    }
+
+    ////////////////////// Signing data //////////////////////
+
+    // should allow to validate the signature from an EOA
+    function test_allow_signatureFromEOA() public {
+        // Get signature
+        bytes32 hash_ = keccak256("hello world");
+
+        bytes memory signature_ = SigningUtilsLib.signHash_EOA(users.alice.privateKey, hash_);
+        assertEq(aliceDeleGator.isValidSignature(hash_, signature_), ERC1271Lib.EIP1271_MAGIC_VALUE);
+    }
+
+    // should fail to validate the signature from a different EOA
+    function test_notAllow_invalidSignatureFromInvalidEOA() public {
+        // Get signature
+        bytes32 hash_ = keccak256("hello world");
+
+        // Show that a short signature is invalid (SIG_VALIDATION_FAILED = 0xffffffff)
+        bytes memory signature_ = SigningUtilsLib.signHash_EOA(users.bob.privateKey, hash_);
+        assertEq(aliceDeleGator.isValidSignature(hash_, signature_), ERC1271Lib.SIG_VALIDATION_FAILED);
+    }
+
+    // should fail to validate a short signature
+    function test_notAllow_invalidSignatureLength() public {
+        // Get signature
+        bytes32 hash_ = keccak256("hello world");
+
+        bytes memory signature_ = hex"ffff";
+        assertEq(aliceDeleGator.isValidSignature(hash_, signature_), ERC1271Lib.SIG_VALIDATION_FAILED);
+    }
+
+    ////////////////////// General //////////////////////
+
+    // Test for function:  execute(Execution calldata _execution)
+    function test_execute_Execution_accessControl() public {
+        // Prepare an example execution call
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+
+        // 1. Call from a random address -> Should revert (NotEntryPointOrSelf)
+        address randomUser_ = address(0xabcdef);
+        vm.deal(randomUser_, 1 ether);
+        vm.prank(randomUser_);
+        vm.expectRevert(EIP7702DeleGatorCore.NotEntryPointOrSelf.selector);
+        aliceDeleGator.execute(execution_);
+
+        // 2. Call from the entry point -> Should succeed
+        uint256 initialCount_ = aliceDeleGatorCounter.count();
+        vm.prank(address(entryPoint));
+        aliceDeleGator.execute(execution_);
+        uint256 finalCount_ = aliceDeleGatorCounter.count();
+        assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented after entryPoint call");
+
+        // 3. Call from the contract itself -> Should succeed
+        initialCount_ = aliceDeleGatorCounter.count();
+        vm.prank(address(aliceDeleGator));
+        aliceDeleGator.execute(execution_);
+        finalCount_ = aliceDeleGatorCounter.count();
+        assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented after self-call");
+    }
+
+    // Test for function: execute(ModeCode _mode, bytes calldata _executionCalldata)
+    function test_execute_ModeCode_accessControl() public {
+        // We'll create a ModeCode that represents a single revert on failure
+        ModeCode singleRevertMode_ = ModeCode.wrap(0);
+
+        // The callData for a single call: (target, value, callData)
+        // We'll encode it via ExecutionLib or by standard abi.encodePacked:
+        bytes memory execCalldata_ =
+            abi.encodePacked(address(aliceDeleGatorCounter), uint256(0), abi.encodeWithSelector(Counter.increment.selector));
+
+        // 1. Call from a random address -> Should revert
+        address randomUser_ = address(0x12345);
+        vm.prank(randomUser_);
+        vm.expectRevert(EIP7702DeleGatorCore.NotEntryPointOrSelf.selector);
+        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+
+        // 2. Call from the entry point -> Should succeed
+        uint256 initialCount_ = aliceDeleGatorCounter.count();
+        vm.prank(address(entryPoint));
+        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+        uint256 finalCount_ = aliceDeleGatorCounter.count();
+        assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented from entryPoint call");
+
+        // 3. Call from the contract itself -> Should succeed
+        initialCount_ = aliceDeleGatorCounter.count();
+        vm.prank(address(aliceDeleGator));
+        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+        finalCount_ = aliceDeleGatorCounter.count();
+        assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented from self-call");
+    }
+
+    // Test supportsExecutionMode() for each of the 4 available modes,
+    function test_supportsExecutionMode() public {
+        ModePayload modePayloadDefault_ = ModePayload.wrap(bytes22(0x00));
+
+        ModeCode singleRevertMode_ = ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, modePayloadDefault_);
+        ModeCode singleTryMode_ = ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, modePayloadDefault_);
+        ModeCode batchRevertMode_ = ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, modePayloadDefault_);
+        ModeCode batchTryMode_ = ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, modePayloadDefault_);
+
+        assertTrue(aliceDeleGator.supportsExecutionMode(singleRevertMode_), "should support single revert");
+        assertTrue(aliceDeleGator.supportsExecutionMode(singleTryMode_), "should support single try");
+        assertTrue(aliceDeleGator.supportsExecutionMode(batchRevertMode_), "should support batch revert");
+        assertTrue(aliceDeleGator.supportsExecutionMode(batchTryMode_), "should support batch try");
+
+        // Test a random/unsupported mode
+        ModeCode unsupportedMode_ = ModeCode.wrap(bytes32(uint256(12345)));
+        assertFalse(aliceDeleGator.supportsExecutionMode(unsupportedMode_), "should not support random mode");
+
+        unsupportedMode_ = ModeLib.encode(CALLTYPE_DELEGATECALL, EXECTYPE_DEFAULT, MODE_DEFAULT, modePayloadDefault_);
+        assertFalse(aliceDeleGator.supportsExecutionMode(unsupportedMode_), "should not suppot unsupported calltype");
+
+        unsupportedMode_ = ModeLib.encode(CALLTYPE_SINGLE, ExecType.wrap(0x02), MODE_DEFAULT, modePayloadDefault_);
+        assertFalse(aliceDeleGator.supportsExecutionMode(unsupportedMode_), "should not suppot unsupported exectype");
+
+        unsupportedMode_ =
+            ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, ModeSelector.wrap(bytes4(0x00000001)), modePayloadDefault_);
+        assertFalse(aliceDeleGator.supportsExecutionMode(unsupportedMode_), "should not suppot unsupported mode selector");
+    }
+}
+
+// @dev Only used for testing the EIP712 constructor validations
+contract EIP7702DeleGatorTestMock is EIP7702DeleGatorCore {
+    constructor(
+        string memory eip712Name_,
+        string memory eip712Version_
+    )
+        EIP7702DeleGatorCore(IDelegationManager(address(0)), IEntryPoint(address(0)), eip712Name_, eip712Version_)
+    { }
+
+    // @dev Implemented to comply with the abstract interface
+    function _isValidSignature(bytes32 _hash, bytes calldata _signature) internal view virtual override returns (bytes4) { }
+}

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -29,6 +29,8 @@ import { DelegationManager } from "../../src/DelegationManager.sol";
 import { DeleGatorCore } from "../../src/DeleGatorCore.sol";
 import { HybridDeleGator } from "../../src/HybridDeleGator.sol";
 import { MultiSigDeleGator } from "../../src/MultiSigDeleGator.sol";
+import { EIP7702StatelessDeleGator } from "../../src/EIP7702/EIP7702StatelessDeleGator.sol";
+import "forge-std/Test.sol";
 
 abstract contract BaseTest is Test {
     using ModeLib for ModeCode;
@@ -55,6 +57,7 @@ abstract contract BaseTest is Test {
     // DeleGator Implementations
     HybridDeleGator public hybridDeleGatorImpl;
     MultiSigDeleGator public multiSigDeleGatorImpl;
+    EIP7702StatelessDeleGator public eip7702StatelessDeleGatorImpl;
 
     // Users
     TestUsers internal users;
@@ -92,6 +95,9 @@ abstract contract BaseTest is Test {
 
         multiSigDeleGatorImpl = new MultiSigDeleGator(delegationManager, entryPoint);
         vm.label(address(multiSigDeleGatorImpl), "MultiSig DeleGator");
+
+        eip7702StatelessDeleGatorImpl = new EIP7702StatelessDeleGator(delegationManager, entryPoint);
+        vm.label(address(eip7702StatelessDeleGatorImpl), "EIP7702Stateless DeleGator");
 
         // Create users
         users = _createUsers();
@@ -365,6 +371,8 @@ abstract contract BaseTest is Test {
             return deployDeleGator_Hybrid(_user);
         } else if (_implementation == Implementation.MultiSig) {
             return deployDeleGator_MultiSig(_user);
+        } else if (_implementation == Implementation.EIP7702Stateless) {
+            return deployDeleGator_EIP7702Stateless(_user);
         } else {
             revert("Invalid Implementation");
         }
@@ -409,6 +417,15 @@ abstract contract BaseTest is Test {
                 abi.encodeWithSignature("initialize(address,string[],uint256[],uint256[])", _owner, _keyIds, _xValues, _yValues)
             )
         );
+    }
+
+    function deployDeleGator_EIP7702Stateless(TestUser memory _user) public returns (address) {
+        return deployDeleGator_EIP7702Stateless(_user.addr);
+    }
+
+    function deployDeleGator_EIP7702Stateless(address _eoaAddress) public returns (address) {
+        vm.etch(_eoaAddress, bytes.concat(hex"ef0100", abi.encodePacked(eip7702StatelessDeleGatorImpl)));
+        return _eoaAddress;
     }
 
     // Name is the seed used to generate the address, private key, and DeleGator.

--- a/test/utils/Types.t.sol
+++ b/test/utils/Types.t.sol
@@ -28,7 +28,8 @@ struct TestUsers {
  */
 enum Implementation {
     MultiSig, // MultiSigDeleGator is a DeleGator that is owned by a set of EOA addresses.
-    Hybrid // HybridDeleGator is a DeleGator that is owned by a set of P256 Keys and EOA
+    Hybrid, // HybridDeleGator is a DeleGator that is owned by a set of P256 Keys and EOA
+    EIP7702Stateless // EIP7702Stateless is a DeleGator that is owned by the EIP7702 EOA
 
 }
 


### PR DESCRIPTION
### **What?**

- New version of the DeleGator contracts. This contract has been created to be used with EIP7702 Accounts. It deletes the UUPS proxy logic that we used to have in the previous DeleGators. it doesn't modify the previous contracts instead it creates a new core and a new implementation. 
- The new implementation is a stateless deleGator that doesn't allow changing the signer/owner of the contract, the only account that can control the smart account is the same EOA where the contracts run. The EOA can interact with the contract via submitting direct transactions to the contract functions, or via the entry point using signatures.

### **Why?**

- The EIP7702 does not require UUPS proxy functionality, because this  EIP updates the smart contracts using a different mechanism.

### **How?**

- New set of contracts without touching the previous ones.
- Deleted namespace storage because there is no storage
