### PR TITLE
Adds Delegation MetaSwap Adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ SALT=0
 DELEGATION_MANAGER_ADDRESS=
 ENTRYPOINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
 MULTISIG_DELEGATOR_IMPLEMENTATION_ADDRESS=
+META_SWAP_ADAPTER_OWNER_ADDRESS=
+METASWAP_ADDRESS=
 
 # Required for verifying contracts
 ETHERSCAN_API_KEY=
@@ -15,13 +17,13 @@ POLYGONSCAN_API_KEY=
 
 
 # RPC URLs
-MAINNET_RPC_URL=https://mainnet.infura.io/v3/...
-ARBITRUM_RPC_URL=https://arbitrum-mainnet.infura.io/v3/...
-BASE_RPC_URL=https://base-mainnet.infura.io/v3/...
-LINEA_RPC_URL=https://linea-mainnet.infura.io/v3/...
-OPTIMISM_RPC_URL=https://optimism-mainnet.infura.io/v3/...
-POLYGON_RPC_URL=https://polygon-mainnet.infura.io/v3/...
-SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/...
-LINEA_SEPOLIA_RPC_URL=https://linea-sepolia.infura.io/v3/...
-BASE_SEPOLIA_RPC_URL=https://base-sepolia.infura.io/v3/...
-
+RPC_API_KEY=
+MAINNET_RPC_URL=https://mainnet.infura.io/v3/${RPC_API_KEY}
+ARBITRUM_RPC_URL=https://arbitrum-mainnet.infura.io/v3/${RPC_API_KEY}
+BASE_RPC_URL=https://base-mainnet.infura.io/v3/${RPC_API_KEY}
+LINEA_RPC_URL=https://linea-mainnet.infura.io/v3/${RPC_API_KEY}
+OPTIMISM_RPC_URL=https://optimism-mainnet.infura.io/v3/${RPC_API_KEY}
+POLYGON_RPC_URL=https://polygon-mainnet.infura.io/v3/${RPC_API_KEY}
+SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/${RPC_API_KEY}
+LINEA_SEPOLIA_RPC_URL=https://linea-sepolia.infura.io/v3/${RPC_API_KEY}
+BASE_SEPOLIA_RPC_URL=https://base-sepolia.infura.io/v3/${RPC_API_KEY}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,9 @@ jobs:
         run: forge install
 
       - name: Check contract sizes
-        run: forge build --sizes --skip test --skip script
+        run: forge build --sizes --skip test --skip script --optimize true
 
       - name: Run tests
         run: forge test -vvv
+        env:
+          LINEA_RPC_URL: ${{ secrets.LINEA_RPC_URL }}

--- a/script/DeployDelegationMetaSwapAdapter.s.sol
+++ b/script/DeployDelegationMetaSwapAdapter.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { DelegationMetaSwapAdapter } from "../src/helpers/DelegationMetaSwapAdapter.sol";
+import { IDelegationManager } from "../src/interfaces/IDelegationManager.sol";
+import { IMetaSwap } from "../src/helpers/interfaces/IMetaSwap.sol";
+
+/**
+ * @title DeployDelegationMetaSwapAdapter
+ * @notice Deploys the delegationMetaSwapAdapter contract.
+ * @dev These contracts are likely already deployed on a testnet or mainnet as many are singletons.
+ * @dev Fill the required variables in the .env file
+ * @dev run the script with:
+ * forge script script/DeployDelegationMetaSwapAdapter.s.sol --rpc-url <your_rpc_url> --private-key $PRIVATE_KEY --broadcast
+ */
+contract DeployDelegationMetaSwapAdapter is Script {
+    bytes32 salt;
+    address deployer;
+    address metaSwapAdapterOwner;
+    IDelegationManager delegationManager;
+    IMetaSwap metaSwap;
+
+    function setUp() public {
+        salt = bytes32(abi.encodePacked(vm.envString("SALT")));
+        metaSwapAdapterOwner = vm.envAddress("META_SWAP_ADAPTER_OWNER_ADDRESS");
+        delegationManager = IDelegationManager(vm.envAddress("DELEGATION_MANAGER_ADDRESS"));
+        metaSwap = IMetaSwap(vm.envAddress("METASWAP_ADDRESS"));
+        deployer = msg.sender;
+        console2.log("~~~");
+        console2.log("Deployer: %s", address(deployer));
+        console2.log("DelegationMetaSwapAdapter Owner %s", address(metaSwapAdapterOwner));
+        console2.log("Salt:");
+        console2.logBytes32(salt);
+    }
+
+    function run() public {
+        console2.log("~~~");
+        vm.startBroadcast();
+
+        address delegationMetaSwapAdapter =
+            address(new DelegationMetaSwapAdapter{ salt: salt }(metaSwapAdapterOwner, delegationManager, metaSwap));
+        console2.log("DelegationMetaSwapAdapter: %s", delegationMetaSwapAdapter);
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/helpers/DelegationMetaSwapAdapter.sol
+++ b/src/helpers/DelegationMetaSwapAdapter.sol
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ExecutionHelper } from "@erc7579/core/ExecutionHelper.sol";
+
+import { IMetaSwap } from "./interfaces/IMetaSwap.sol";
+import { IDelegationManager } from "../interfaces/IDelegationManager.sol";
+import { CallType, ExecType, Execution, Delegation, ModeCode } from "../utils/Types.sol";
+import { CALLTYPE_SINGLE, CALLTYPE_BATCH, EXECTYPE_DEFAULT, EXECTYPE_TRY } from "../utils/Constants.sol";
+
+/**
+ * @title DelegationMetaSwapAdapter
+ * @notice Acts as a middleman to orchestrate token swaps using delegations
+ *         and an aggregator (MetaSwap).
+ */
+contract DelegationMetaSwapAdapter is ExecutionHelper, Ownable2Step {
+    using ModeLib for ModeCode;
+    using ExecutionLib for bytes;
+    using SafeERC20 for IERC20;
+
+    ////////////////////////////// State //////////////////////////////
+
+    /// @dev The DelegationManager contract that has root access to this contract
+    IDelegationManager public immutable delegationManager;
+
+    /// @dev The MetaSwap contract used to swap tokens
+    IMetaSwap public immutable metaSwap;
+
+    /// @dev Indicates if a token is allowed to be used in the swaps
+    mapping(IERC20 token => bool allowed) public isTokenAllowed;
+
+    /// @dev A mapping indicating if an aggregator ID hash is allowed.
+    mapping(bytes32 aggregatorIdHash => bool allowed) public isAggregatorAllowed;
+
+    ////////////////////////////// Events //////////////////////////////
+
+    /// @dev Emitted when the DelegationManager contract address is set.
+    event SetDelegationManager(IDelegationManager indexed newDelegationManager);
+
+    /// @dev Emitted when the MetaSwap contract address is set.
+    event SetMetaSwap(IMetaSwap indexed newMetaSwap);
+
+    /// @dev Emitted when the contract sends tokens (or native tokens) to a recipient.
+    event SentTokens(IERC20 indexed token, address indexed recipient, uint256 amount);
+
+    /// @dev Emitted when the allowed token status changes for a token.
+    event ChangedTokenStatus(IERC20 token, bool status);
+
+    /// @dev Emitted when the allowed aggregator ID status changes.
+    event ChangedAggregatorIdStatus(bytes32 indexed aggregatorIdHash, string aggregatorId, bool status);
+
+    ////////////////////////////// Errors //////////////////////////////
+
+    /// @dev Error thrown when the caller is not the delegation manager
+    error NotDelegationManager();
+
+    /// @dev Error thrown when the call is not made by this contract itself.
+    error NotSelf();
+
+    /// @dev Error thrown when an execution with an unsupported CallType is made.
+    error UnsupportedCallType(CallType callType);
+
+    /// @dev Error thrown when an execution with an unsupported ExecType is made.
+    error UnsupportedExecType(ExecType execType);
+
+    /// @dev Error thrown when the input and output tokens are the same.
+    error InvalidIdenticalTokens();
+
+    /// @dev  Error thrown when delegations input is an empty array.
+    error InvalidEmptyDelegations();
+
+    /// @dev Error while transferring the native token to the recipient.
+    error FailedNativeTokenTransfer(address recipient);
+
+    /// @dev Error when the tokenFrom is not in the allow list.
+    error TokenFromIsNotAllowed(IERC20 token);
+
+    /// @dev Error when the tokenTo is not in the allow list.
+    error TokenToIsNotAllowed(IERC20 token);
+
+    /// @dev Error when the aggregator ID is not in the allow list.
+    error AggregatorIdIsNotAllowed(string);
+
+    /// @dev Error when the input arrays of a function have different lengths.
+    error InputLengthsMismatch();
+
+    /// @dev Error when the contract did not receive enough tokens to perform the swap.
+    error InsufficientTokens();
+
+    ////////////////////////////// Modifiers //////////////////////////////
+
+    /**
+     * @notice Require the function call to come from the DelegationManager.
+     */
+    modifier onlyDelegationManager() {
+        if (msg.sender != address(delegationManager)) revert NotDelegationManager();
+        _;
+    }
+
+    /**
+     * @notice Require the function call to come from the this contract itself.
+     */
+    modifier onlySelf() {
+        if (msg.sender != address(this)) revert NotSelf();
+        _;
+    }
+
+    ////////////////////////////// Constructor //////////////////////////////
+
+    /**
+     * @notice Initializes the DelegationMetaSwapAdapter contract
+     * @param _owner The initial owner of the contract
+     * @param _delegationManager the address of the trusted DelegationManager contract that will have root access to this contract
+     * @param _metaSwap the address of the trusted MetaSwap contract.
+     */
+    constructor(address _owner, IDelegationManager _delegationManager, IMetaSwap _metaSwap) Ownable(_owner) {
+        delegationManager = _delegationManager;
+        metaSwap = _metaSwap;
+        emit SetDelegationManager(_delegationManager);
+        emit SetMetaSwap(_metaSwap);
+    }
+
+    ////////////////////////////// External Methods //////////////////////////////
+
+    /**
+     * @notice Allows this contract to receive the chain's native token.
+     */
+    receive() external payable { }
+
+    /**
+     * @notice Executes a token swap using a delegation and transfers the swapped tokens to the root delegator.
+     * @param _apiData Encoded swap parameters, used by the aggregator.
+     * @param _delegations Array of Delegation objects containing delegation-specific data.
+     */
+    function swapByDelegation(bytes calldata _apiData, Delegation[] memory _delegations) external {
+        (string memory aggregatorId_, IERC20 tokenFrom_, IERC20 tokenTo_, uint256 amountFrom_, bytes memory swapData_) =
+            _decodeApiData(_apiData);
+        uint256 delegationsLength_ = _delegations.length;
+
+        if (delegationsLength_ == 0) revert InvalidEmptyDelegations();
+        if (tokenFrom_ == tokenTo_) revert InvalidIdenticalTokens();
+        if (!isTokenAllowed[tokenFrom_]) revert TokenFromIsNotAllowed(tokenFrom_);
+        if (!isTokenAllowed[tokenTo_]) revert TokenToIsNotAllowed(tokenTo_);
+        if (!isAggregatorAllowed[keccak256(abi.encode(aggregatorId_))]) revert AggregatorIdIsNotAllowed(aggregatorId_);
+
+        // Prepare the call that will be executed internally via onlySelf
+        bytes memory encodedSwap_ = abi.encodeWithSelector(
+            this.swapTokens.selector,
+            aggregatorId_,
+            tokenFrom_,
+            tokenTo_,
+            _delegations[delegationsLength_ - 1].delegator,
+            amountFrom_,
+            _getSelfBalance(tokenFrom_),
+            swapData_
+        );
+
+        bytes[] memory permissionContexts_ = new bytes[](2);
+        permissionContexts_[0] = abi.encode(_delegations);
+        permissionContexts_[1] = abi.encode(new Delegation[](0));
+
+        ModeCode[] memory encodedModes_ = new ModeCode[](2);
+        encodedModes_[0] = ModeLib.encodeSimpleSingle();
+        encodedModes_[1] = ModeLib.encodeSimpleSingle();
+
+        bytes[] memory executionCallDatas_ = new bytes[](2);
+
+        if (address(tokenFrom_) == address(0)) {
+            executionCallDatas_[0] = ExecutionLib.encodeSingle(address(this), amountFrom_, hex"");
+        } else {
+            bytes memory encodedTransfer_ = abi.encodeWithSelector(IERC20.transfer.selector, address(this), amountFrom_);
+            executionCallDatas_[0] = ExecutionLib.encodeSingle(address(tokenFrom_), 0, encodedTransfer_);
+        }
+        executionCallDatas_[1] = ExecutionLib.encodeSingle(address(this), 0, encodedSwap_);
+
+        delegationManager.redeemDelegations(permissionContexts_, encodedModes_, executionCallDatas_);
+    }
+
+    /**
+     * @notice Executes the actual token swap via the MetaSwap contract and transfer the output tokens to the recipient.
+     * @dev This function can only be called internally by this contract (`onlySelf`).
+     * @param _aggregatorId The identifier for the swap aggregator/DEX aggregator.
+     * @param _tokenFrom The input token of the swap.
+     * @param _tokenTo The output token of the swap.
+     * @param _recipient The address that will receive the swapped tokens.
+     * @param _amountFrom The amount of tokens to be swapped.
+     * @param _balanceFromBefore The contract’s balance of _tokenFrom before the incoming token transfer is credited.
+     * @param _swapData Arbitrary data required by the aggregator (e.g. encoded swap params).
+     */
+    function swapTokens(
+        string calldata _aggregatorId,
+        IERC20 _tokenFrom,
+        IERC20 _tokenTo,
+        address _recipient,
+        uint256 _amountFrom,
+        uint256 _balanceFromBefore,
+        bytes calldata _swapData
+    )
+        external
+        onlySelf
+    {
+        uint256 tokenFromObtained_ = _getSelfBalance(_tokenFrom) - _balanceFromBefore;
+        if (tokenFromObtained_ < _amountFrom) revert InsufficientTokens();
+
+        if (tokenFromObtained_ > _amountFrom) {
+            _sendTokens(_tokenFrom, tokenFromObtained_ - _amountFrom, _recipient);
+        }
+
+        uint256 balanceToBefore_ = _getSelfBalance(_tokenTo);
+
+        uint256 value_ = 0;
+
+        if (address(_tokenFrom) == address(0)) {
+            value_ = _amountFrom;
+        } else {
+            uint256 allowance_ = _tokenFrom.allowance(address(this), address(metaSwap));
+            if (allowance_ < _amountFrom) {
+                _tokenFrom.safeIncreaseAllowance(address(metaSwap), type(uint256).max);
+            }
+        }
+
+        metaSwap.swap{ value: value_ }(_aggregatorId, _tokenFrom, _amountFrom, _swapData);
+
+        uint256 obtainedAmount_ = _getSelfBalance(_tokenTo) - balanceToBefore_;
+
+        _sendTokens(_tokenTo, obtainedAmount_, _recipient);
+    }
+
+    /**
+     * @notice Executes one or multiple calls on behalf of this contract,
+     *         authorized by the DelegationManager.
+     * @dev Only callable by the DelegationManager. Supports both single-call and
+     *      batch-call execution, and handles the revert-or-try logic via ExecType.
+     * @dev Related: @erc7579/MSAAdvanced.sol
+     * @param _mode The encoded execution mode of the transaction (CallType, ExecType, etc.).
+     * @param _executionCalldata The encoded call data (single or batch) to be executed.
+     * @return returnData_ An array of returned data from each executed call.
+     */
+    function executeFromExecutor(
+        ModeCode _mode,
+        bytes calldata _executionCalldata
+    )
+        external
+        payable
+        onlyDelegationManager
+        returns (bytes[] memory returnData_)
+    {
+        (CallType callType_, ExecType execType_,,) = _mode.decode();
+
+        // Check if calltype is batch or single
+        if (callType_ == CALLTYPE_BATCH) {
+            // Destructure executionCallData according to batched exec
+            Execution[] calldata executions_ = _executionCalldata.decodeBatch();
+            // check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) returnData_ = _execute(executions_);
+            else if (execType_ == EXECTYPE_TRY) returnData_ = _tryExecute(executions_);
+            else revert UnsupportedExecType(execType_);
+        } else if (callType_ == CALLTYPE_SINGLE) {
+            // Destructure executionCallData according to single exec
+            (address target_, uint256 value_, bytes calldata callData_) = _executionCalldata.decodeSingle();
+            returnData_ = new bytes[](1);
+            bool success_;
+            // check if execType is revert or try
+            if (execType_ == EXECTYPE_DEFAULT) {
+                returnData_[0] = _execute(target_, value_, callData_);
+            } else if (execType_ == EXECTYPE_TRY) {
+                (success_, returnData_[0]) = _tryExecute(target_, value_, callData_);
+                if (!success_) emit TryExecuteUnsuccessful(0, returnData_[0]);
+            } else {
+                revert UnsupportedExecType(execType_);
+            }
+        } else {
+            revert UnsupportedCallType(callType_);
+        }
+    }
+
+    /**
+     * @notice Withdraws a specified token from the contract to a recipient.
+     * @dev Only callable by the contract owner.
+     * @param _token The token to be withdrawn (use address(0) for native token).
+     * @param _amount The amount of tokens (or native) to withdraw.
+     * @param _recipient The address to receive the withdrawn tokens.
+     */
+    function withdraw(IERC20 _token, uint256 _amount, address _recipient) external onlyOwner {
+        _sendTokens(_token, _amount, _recipient);
+    }
+
+    /**
+     * @notice Updates the allowed (whitelist) status of multiple tokens in a single call.
+     * @dev Only callable by the contract owner.
+     * @param _tokens Array of tokens to modify.
+     * @param _statuses Corresponding array of booleans to set each token's allowed status.
+     */
+    function updateAllowedTokens(IERC20[] calldata _tokens, bool[] calldata _statuses) external onlyOwner {
+        uint256 tokensLength_ = _tokens.length;
+        if (tokensLength_ != _statuses.length) revert InputLengthsMismatch();
+
+        for (uint256 i = 0; i < tokensLength_; ++i) {
+            IERC20 token = _tokens[i];
+            bool status_ = _statuses[i];
+            if (isTokenAllowed[token] != status_) {
+                isTokenAllowed[token] = status_;
+
+                emit ChangedTokenStatus(token, status_);
+            }
+        }
+    }
+
+    /**
+     * @notice Updates the allowed (whitelist) status of multiple aggregator IDs in a single call.
+     * @dev Only callable by the contract owner.
+     * @param _aggregatorIds Array of aggregator ID strings.
+     * @param _statuses Corresponding array of booleans (true = allowed, false = disallowed).
+     */
+    function updateAllowedAggregatorIds(string[] calldata _aggregatorIds, bool[] calldata _statuses) external onlyOwner {
+        uint256 aggregatorsLength_ = _aggregatorIds.length;
+        if (aggregatorsLength_ != _statuses.length) revert InputLengthsMismatch();
+
+        for (uint256 i = 0; i < aggregatorsLength_; ++i) {
+            bytes32 aggregatorIdHash_ = keccak256(abi.encode(_aggregatorIds[i]));
+            bool status_ = _statuses[i];
+            if (isAggregatorAllowed[aggregatorIdHash_] != status_) {
+                isAggregatorAllowed[aggregatorIdHash_] = status_;
+
+                emit ChangedAggregatorIdStatus(aggregatorIdHash_, _aggregatorIds[i], status_);
+            }
+        }
+    }
+
+    ////////////////////////////// Private/Internal Methods //////////////////////////////
+
+    /**
+     * @notice Sends tokens or native token to a specified recipient.
+     * @param _token ERC20 token to send or address(0) for native token.
+     * @param _amount Amount of tokens or native token to send.
+     * @param _recipient Address to receive the funds.
+     * @dev Reverts if native token transfer fails.
+     */
+    function _sendTokens(IERC20 _token, uint256 _amount, address _recipient) private {
+        if (address(_token) == address(0)) {
+            (bool success_,) = _recipient.call{ value: _amount }("");
+
+            if (!success_) revert FailedNativeTokenTransfer(_recipient);
+        } else {
+            IERC20(_token).safeTransfer(_recipient, _amount);
+        }
+
+        emit SentTokens(_token, _recipient, _amount);
+    }
+
+    /**
+     * @dev Internal helper to decode aggregator data from `apiData`.
+     * @param _apiData Bytes that includes aggregatorId, tokenFrom, amountFrom, and the aggregator swap data.
+     */
+    function _decodeApiData(bytes calldata _apiData)
+        private
+        pure
+        returns (string memory aggregatorId_, IERC20 tokenFrom_, IERC20 tokenTo_, uint256 amountFrom_, bytes memory swapData_)
+    {
+        // Excluding the function selector
+        bytes memory parameterTerms_ = _apiData[4:];
+        (aggregatorId_, tokenFrom_, amountFrom_, swapData_) = abi.decode(parameterTerms_, (string, IERC20, uint256, bytes));
+
+        // Note: Prepend address(0) to format the data correctly because of the Swaps API. See internal docs.
+        (,, tokenTo_,,,,,,) = abi.decode(
+            abi.encodePacked(abi.encode(address(0)), swapData_),
+            (address, IERC20, IERC20, uint256, uint256, bytes, uint256, address, bool)
+        );
+    }
+
+    /**
+     * @dev Returns this contract's balance of the specified ERC20 token.
+     *      If `_token` is address(0), it returns the native token balance.
+     * @param _token The token to check balance for.
+     * @return balance_ The balance of the specified token.
+     */
+    function _getSelfBalance(IERC20 _token) private view returns (uint256 balance_) {
+        if (address(_token) == address(0)) return address(this).balance;
+
+        return _token.balanceOf(address(this));
+    }
+}

--- a/src/helpers/interfaces/IMetaSwap.sol
+++ b/src/helpers/interfaces/IMetaSwap.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMetaSwap {
+    struct Adapter {
+        address addr; // adapter's address
+        bytes4 selector;
+        bytes data; // adapter's fixed data
+    }
+
+    /**
+     * @dev Sets the adapter for an aggregator. It can't be changed later.
+     * @param aggregatorId Aggregator's identifier
+     * @param addr Address of the contract that contains the logic for this aggregator
+     * @param selector The function selector of the swap function in the adapter
+     * @param data Fixed abi encoded data the will be passed in each delegatecall made to the adapter
+     */
+    function setAdapter(string calldata aggregatorId, address addr, bytes4 selector, bytes calldata data) external;
+
+    /**
+     * @dev Removes the adapter for an existing aggregator. This can't be undone.
+     * @param aggregatorId Aggregator's identifier
+     */
+    function removeAdapter(string calldata aggregatorId) external;
+
+    /**
+     * @dev Performs a swap
+     * @param aggregatorId Identifier of the aggregator to be used for the swap
+     * @param data Dynamic data which is concatenated with the fixed aggregator's
+     * data in the delecatecall made to the adapter
+     */
+    function swap(string calldata aggregatorId, IERC20 tokenFrom, uint256 amount, bytes calldata data) external payable;
+
+    function adapters(string memory id) external view returns (Adapter memory);
+}

--- a/test/helpers/DelegationMetaSwapAdapter.t.sol
+++ b/test/helpers/DelegationMetaSwapAdapter.t.sol
@@ -1,0 +1,781 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { BasicERC20 } from "../utils/BasicERC20.t.sol";
+import { BaseTest } from "../utils/BaseTest.t.sol";
+import { DelegationMetaSwapAdapter } from "../../src/helpers/DelegationMetaSwapAdapter.sol";
+import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
+import { Implementation, SignatureType, TestUser } from "../utils/Types.t.sol";
+import { Delegation, Caveat, ModeCode } from "../../src/utils/Types.sol";
+import { IDelegationManager } from "../../src/interfaces/IDelegationManager.sol";
+import { IMetaSwap } from "../../src/helpers/interfaces/IMetaSwap.sol";
+import { AllowedTargetsEnforcer } from "../../src/enforcers/AllowedTargetsEnforcer.sol";
+import { AllowedCalldataEnforcer } from "../../src/enforcers/AllowedCalldataEnforcer.sol";
+import { AllowedMethodsEnforcer } from "../../src/enforcers/AllowedMethodsEnforcer.sol";
+import { ValueLteEnforcer } from "../../src/enforcers/ValueLteEnforcer.sol";
+import { RedeemerEnforcer } from "../../src/enforcers/RedeemerEnforcer.sol";
+import { BytesLib } from "@bytes-utils/BytesLib.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { DelegationManager } from "../../src/DelegationManager.sol";
+import { HybridDeleGator } from "../../src/HybridDeleGator.sol";
+import { EntryPoint } from "@account-abstraction/core/EntryPoint.sol";
+import "forge-std/Test.sol";
+
+/**
+ * @title DelegationMetaSwapAdapterBaseTest
+ * @notice All common state, shared helper functions and common setup are in this
+ *          abstract contract.
+ */
+abstract contract DelegationMetaSwapAdapterBaseTest is BaseTest {
+    using MessageHashUtils for bytes32;
+
+    ////////////////////////////// State & Constants //////////////////////////////
+
+    DelegationMetaSwapAdapter public delegationMetaSwapAdapter;
+    address public owner = makeAddr("DelegationMetaSwapAdapter Owner");
+    IMetaSwap public metaSwapMock;
+    BasicERC20 public tokenA;
+    BasicERC20 public tokenB;
+    uint256 public amountFrom = 1 ether;
+    uint256 public amountTo = 1 ether;
+    string public aggregatorId = "1";
+    TestUser public vault;
+    TestUser public subVault;
+    AllowedCalldataEnforcer public allowedCalldataEnforcer;
+    AllowedTargetsEnforcer public allowedTargetsEnforcer;
+    AllowedMethodsEnforcer public allowedMethodsEnforcer;
+    ValueLteEnforcer public valueLteEnforcer;
+
+    RedeemerEnforcer public redeemerEnforcer;
+    bytes public swapDataTokenAtoTokenB;
+
+    //////////////////////// Constructor & Setup ////////////////////////
+
+    constructor() {
+        IMPLEMENTATION = Implementation.Hybrid;
+        SIGNATURE_TYPE = SignatureType.RawP256;
+    }
+
+    function setUp() public virtual override {
+        // Common setup for both mock and fork tests
+        super.setUp();
+        allowedCalldataEnforcer = new AllowedCalldataEnforcer();
+        allowedTargetsEnforcer = new AllowedTargetsEnforcer();
+        allowedMethodsEnforcer = new AllowedMethodsEnforcer();
+        valueLteEnforcer = new ValueLteEnforcer();
+        redeemerEnforcer = new RedeemerEnforcer();
+    }
+
+    //////////////////////// Internal / Private Helpers ////////////////////////
+
+    /**
+     * @dev Internal helper to decode aggregator data from `apiData`.
+     *      Typically used in fork-based tests.
+     * @param _apiData Bytes that includes aggregatorId, tokenFrom, amountFrom, and the aggregator swap data.
+     */
+    function _decodeApiData(bytes memory _apiData)
+        internal
+        pure
+        returns (string memory aggregatorId_, IERC20 tokenFrom_, uint256 amountFrom_, bytes memory swapData_)
+    {
+        // Excluding the function selector
+        bytes memory parameterTerms_ = BytesLib.slice(_apiData, 4, _apiData.length - 4);
+        (aggregatorId_, tokenFrom_, amountFrom_, swapData_) = abi.decode(parameterTerms_, (string, IERC20, uint256, bytes));
+    }
+
+    /**
+     * @dev Decodes the "swap data" for aggregator usage into tokens and amounts.
+     */
+    function _decodeApiSwapData(bytes memory _swapData)
+        internal
+        pure
+        returns (IERC20 tokenFrom_, IERC20 tokenTo_, uint256 amountFrom_, uint256 amountTo_)
+    {
+        (, tokenFrom_, tokenTo_, amountFrom_, amountTo_,,,,) = abi.decode(
+            abi.encodePacked(abi.encode(address(0)), _swapData),
+            (address, IERC20, IERC20, uint256, uint256, bytes, uint256, address, bool)
+        );
+    }
+
+    /**
+     * @dev Encodes api data for local mocking.
+     */
+    function _encodeApiData(
+        string memory _aggregatorId,
+        IERC20 _tokenFrom,
+        uint256 _amountFrom,
+        bytes memory _swapData
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(IMetaSwap.swap.selector, _aggregatorId, _tokenFrom, _amountFrom, _swapData);
+    }
+
+    /**
+     * @dev Encodes swap data for local mocking. The aggregator would decode these fields (token addresses, amounts, etc.).
+     */
+    function _encodeSwapData(
+        IERC20 _tokenFrom,
+        IERC20 _tokenTo,
+        uint256 _amountFrom,
+        uint256 _amountTo,
+        bytes memory _data,
+        uint256 _fee,
+        address _feeWallet,
+        bool _feeTo
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(_tokenFrom, _tokenTo, _amountFrom, _amountTo, _data, _fee, _feeWallet, _feeTo);
+    }
+
+    function _getCaveatsVaultDelegationNativeToken() private view returns (Caveat[] memory) {
+        Caveat[] memory caveats_ = new Caveat[](2);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(valueLteEnforcer), terms: abi.encode(uint256(10 ether)) });
+
+        caveats_[1] = Caveat({
+            args: hex"",
+            enforcer: address(redeemerEnforcer),
+            terms: abi.encodePacked(address(delegationMetaSwapAdapter))
+        });
+        return caveats_;
+    }
+
+    function _getCaveatsVaultDelegationErc20() private view returns (Caveat[] memory) {
+        Caveat[] memory caveats_ = new Caveat[](4);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(allowedTargetsEnforcer), terms: abi.encodePacked(address(tokenA)) });
+
+        caveats_[1] =
+            Caveat({ args: hex"", enforcer: address(allowedMethodsEnforcer), terms: abi.encodePacked(IERC20.transfer.selector) });
+
+        uint256 paramStart_ = abi.encodeWithSelector(IERC20.transfer.selector).length;
+        address paramValue_ = address(delegationMetaSwapAdapter);
+        // The param start and and param value are packed together, but the param value is not packed.
+        bytes memory inputTerms_ = abi.encodePacked(paramStart_, bytes32(uint256(uint160(paramValue_))));
+        caveats_[2] = Caveat({ args: hex"", enforcer: address(allowedCalldataEnforcer), terms: inputTerms_ });
+
+        caveats_[3] = Caveat({
+            args: hex"",
+            enforcer: address(redeemerEnforcer),
+            terms: abi.encodePacked(address(delegationMetaSwapAdapter))
+        });
+        return caveats_;
+    }
+
+    /**
+     * @dev Builds a Delegation struct representing `vault` delegating to `subVault`.
+     */
+    function _getVaultDelegation() internal view returns (Delegation memory) {
+        Caveat[] memory caveats_ =
+            address(tokenA) == address(0) ? _getCaveatsVaultDelegationNativeToken() : _getCaveatsVaultDelegationErc20();
+
+        Delegation memory vaultDelegation_ = Delegation({
+            delegate: address(subVault.deleGator),
+            delegator: address(vault.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        return signDelegation(vault, vaultDelegation_);
+    }
+
+    /**
+     * @dev Builds a Delegation struct representing `subVault` delegating to `delegationMetaSwapAdapter` with certain restrictions.
+     * @param _parentDelegationHash The hash of the parent delegation.
+     */
+    function _getSubVaultDelegation(bytes32 _parentDelegationHash) internal view returns (Delegation memory) {
+        Caveat[] memory caveats_ = new Caveat[](1);
+
+        if (address(tokenA) == address(0)) {
+            // Using native token as tokenFrom
+            bytes memory inputTerms_ = abi.encodePacked(address(delegationMetaSwapAdapter));
+            caveats_[0] = Caveat({ args: hex"", enforcer: address(allowedTargetsEnforcer), terms: inputTerms_ });
+        } else {
+            // Using ERC20 as tokenFrom
+            // Restricts the amount of tokens per call
+            uint256 paramStart_ = abi.encodeWithSelector(IERC20.transfer.selector, address(0)).length;
+            uint256 paramValue_ = amountFrom;
+            bytes memory inputTerms_ = abi.encodePacked(paramStart_, paramValue_);
+            caveats_[0] = Caveat({ args: hex"", enforcer: address(allowedCalldataEnforcer), terms: inputTerms_ });
+        }
+
+        Delegation memory subVaultDelegation_ = Delegation({
+            delegate: address(delegationMetaSwapAdapter),
+            delegator: address(subVault.deleGator),
+            authority: _parentDelegationHash,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+
+        return signDelegation(subVault, subVaultDelegation_);
+    }
+
+    /**
+     * @dev Edits the allowed tokens for DelegationMetaSwapAdapter, whitelisting tokenA and tokenB.
+     */
+    function _updateAllowedTokens() internal {
+        IERC20[] memory allowedTokens_ = new IERC20[](3);
+        allowedTokens_[0] = IERC20(tokenA);
+        allowedTokens_[1] = IERC20(tokenB);
+        allowedTokens_[2] = IERC20(address(0));
+        bool[] memory statuses_ = new bool[](3);
+        statuses_[0] = true;
+        statuses_[1] = true;
+        statuses_[2] = true;
+
+        vm.prank(owner);
+        delegationMetaSwapAdapter.updateAllowedTokens(allowedTokens_, statuses_);
+    }
+
+    /**
+     * @dev Whitelists an aggregator ID string so DelegationMetaSwapAdapter can use it.
+     * @param _aggregatorId The aggregator ID string
+     */
+    function _whiteListAggregatorId(string memory _aggregatorId) internal {
+        string[] memory aggregatorIds_ = new string[](1);
+        aggregatorIds_[0] = _aggregatorId;
+        bool[] memory statuses_ = new bool[](1);
+        statuses_[0] = true;
+
+        vm.prank(owner);
+        delegationMetaSwapAdapter.updateAllowedAggregatorIds(aggregatorIds_, statuses_);
+    }
+}
+
+/**
+ * @title DelegationMetaSwapAdapterMockTest
+ * @notice These tests run in a purely local environment. No fork is created.
+ */
+contract DelegationMetaSwapAdapterMockTest is DelegationMetaSwapAdapterBaseTest {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /**
+     * @notice Verifies that tokens can be swapped by delegations in a purely local environment (using a MetaSwapMock).
+     */
+    function test_canSwapByDelegationsMockErc20TokenFrom() public {
+        _setUpMockContracts();
+
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        uint256 vaultTokenABalanceBefore_ = tokenA.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenBBalanceBefore_ = tokenB.balanceOf(address(vault.deleGator));
+
+        bytes memory swapData_ = _encodeSwapData(IERC20(tokenA), IERC20(tokenB), amountFrom, amountTo, hex"", 0, address(0), false);
+        bytes memory apiData_ = _encodeApiData(aggregatorId, IERC20(tokenA), amountFrom, swapData_);
+
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(apiData_, delegations_);
+
+        uint256 vaultTokenAUsed_ = vaultTokenABalanceBefore_ - tokenA.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenBObtained_ = tokenB.balanceOf(address(vault.deleGator)) - vaultTokenBBalanceBefore_;
+        assertEq(vaultTokenAUsed_, amountFrom, "Vault should spend the specified amount of tokenA");
+        assertEq(vaultTokenBObtained_, amountTo, "Vault should receive the correct amount of tokenB");
+    }
+
+    /**
+     * @notice Verifies that native token (ETH) can be used as the tokenFrom in a delegation-based swap.
+     * In this test, tokenA is set to ETH (address(0)) while tokenB remains an ERC20.
+     */
+    function test_canSwapByDelegationsMockNativeTokenFrom() public {
+        // Set up contracts: use native token for tokenA (tokenFrom), ERC20 for tokenB.
+        _setUpMockContractsEth(true, false);
+
+        // Build the delegation chain as in the ERC20 test.
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        // Record vault's ETH and tokenB balances before swap.
+        uint256 vaultEthBalanceBefore = address(vault.deleGator).balance;
+        uint256 vaultTokenBBalanceBefore = tokenB.balanceOf(address(vault.deleGator));
+
+        // Prepare the swapData – note that tokenA is ETH (address(0))
+        bytes memory swapData_ = _encodeSwapData(IERC20(tokenA), IERC20(tokenB), amountFrom, amountTo, hex"", 0, address(0), true);
+        bytes memory apiData_ = _encodeApiData(aggregatorId, IERC20(tokenA), amountFrom, swapData_);
+
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(apiData_, delegations_);
+
+        // Calculate the change in balances.
+        uint256 vaultEthUsed = vaultEthBalanceBefore - address(vault.deleGator).balance;
+        uint256 vaultTokenBObtained = tokenB.balanceOf(address(vault.deleGator)) - vaultTokenBBalanceBefore;
+        assertEq(vaultEthUsed, amountFrom, "Vault should spend the specified amount of ETH");
+        assertEq(vaultTokenBObtained, amountTo, "Vault should receive the correct amount of tokenB");
+    }
+
+    /**
+     * @notice Verifies that native token (ETH) can be used as the tokenTo in a delegation-based swap.
+     * In this test, tokenB is set to ETH (address(0)) while tokenA remains an ERC20.
+     */
+    function test_canSwapByDelegationsMockNativeTo() public {
+        // Set up contracts: use ERC20 for tokenA and native token for tokenB.
+        _setUpMockContractsEth(false, true);
+
+        // Build the delegation chain.
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        // Record vault's tokenA balance and ETH balance before swap.
+        uint256 vaultTokenABalanceBefore = tokenA.balanceOf(address(vault.deleGator));
+        uint256 vaultEthBalanceBefore = address(vault.deleGator).balance;
+
+        // Prepare the swapData – tokenTo is now ETH (address(0)). Note that _feeTo is false.
+        bytes memory swapData_ = _encodeSwapData(IERC20(tokenA), IERC20(tokenB), amountFrom, amountTo, hex"", 0, address(0), false);
+        bytes memory apiData_ = _encodeApiData(aggregatorId, IERC20(tokenA), amountFrom, swapData_);
+
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(apiData_, delegations_);
+
+        // Calculate the change in balances.
+        uint256 vaultTokenAUsed = vaultTokenABalanceBefore - tokenA.balanceOf(address(vault.deleGator));
+        uint256 vaultEthObtained = address(vault.deleGator).balance - vaultEthBalanceBefore;
+        assertEq(vaultTokenAUsed, amountFrom, "Vault should spend the specified amount of tokenA");
+        assertEq(vaultEthObtained, amountTo, "Vault should receive the correct amount of ETH");
+    }
+
+    /// @notice Verifies that only the current owner can initiate ownership transfer.
+    function test_revert_transferOwnership_ifNotOwner() public {
+        _setUpMockContracts();
+
+        address newOwner_ = makeAddr("NewOwner");
+        vm.startPrank(address(subVault.deleGator));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(subVault.deleGator)));
+        delegationMetaSwapAdapter.transferOwnership(newOwner_);
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that the owner can successfully transfer ownership in two steps.
+    function test_canTransferAndAcceptOwnership() public {
+        _setUpMockContracts();
+
+        address newOwner_ = makeAddr("NewOwner");
+
+        vm.startPrank(owner);
+        delegationMetaSwapAdapter.transferOwnership(newOwner_);
+        assertEq(delegationMetaSwapAdapter.owner(), owner);
+        vm.stopPrank();
+
+        vm.startPrank(newOwner_);
+        delegationMetaSwapAdapter.acceptOwnership();
+        assertEq(delegationMetaSwapAdapter.owner(), newOwner_);
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that only the pending owner can accept ownership after transferOwnership.
+    function test_revert_acceptOwnership_ifNotPendingOwner() public {
+        _setUpMockContracts();
+
+        address newOwner = makeAddr("NewOwner");
+        vm.startPrank(owner);
+        delegationMetaSwapAdapter.transferOwnership(newOwner);
+        vm.stopPrank();
+
+        address attacker = makeAddr("Attacker");
+        vm.startPrank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(attacker)));
+        delegationMetaSwapAdapter.acceptOwnership();
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that the contract owner can edit allowed tokens and the correct changes are applied.
+    function test_canUpdateAllowedTokens() public {
+        _setUpMockContracts();
+        BasicERC20 tokenC_ = new BasicERC20(owner, "TokenC", "TKC", 0);
+
+        IERC20[] memory tokens_ = new IERC20[](2);
+        tokens_[0] = IERC20(tokenA);
+        tokens_[1] = IERC20(tokenC_);
+
+        bool[] memory statuses_ = new bool[](2);
+        statuses_[0] = false;
+        statuses_[1] = true;
+
+        vm.startPrank(owner);
+        delegationMetaSwapAdapter.updateAllowedTokens(tokens_, statuses_);
+        vm.stopPrank();
+
+        assertFalse(delegationMetaSwapAdapter.isTokenAllowed(tokenA));
+        assertTrue(delegationMetaSwapAdapter.isTokenAllowed(tokenC_));
+    }
+
+    /// @notice Verifies that non-owners cannot call updateAllowedTokens.
+    function test_revert_updateAllowedTokens_ifNotOwner() public {
+        _setUpMockContracts();
+
+        IERC20[] memory tokens_ = new IERC20[](1);
+        tokens_[0] = IERC20(tokenA);
+
+        bool[] memory statuses_ = new bool[](1);
+        statuses_[0] = false;
+
+        vm.startPrank(address(subVault.deleGator));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(subVault.deleGator)));
+        delegationMetaSwapAdapter.updateAllowedTokens(tokens_, statuses_);
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that updateAllowedTokens reverts if array lengths mismatch.
+    function test_revert_updateAllowedTokens_arrayLengthMismatch() public {
+        _setUpMockContracts();
+
+        IERC20[] memory tokens_ = new IERC20[](2);
+        tokens_[0] = IERC20(tokenA);
+        tokens_[1] = IERC20(tokenB);
+
+        bool[] memory statuses_ = new bool[](1);
+        statuses_[0] = false;
+
+        vm.startPrank(owner);
+        vm.expectRevert(abi.encodeWithSelector(DelegationMetaSwapAdapter.InputLengthsMismatch.selector));
+        delegationMetaSwapAdapter.updateAllowedTokens(tokens_, statuses_);
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that the contract owner can update allowed aggregator IDs and the correct changes are applied.
+    function test_canUpdateAllowedAggregatorIds() public {
+        _setUpMockContracts();
+
+        string[] memory aggregatorIds_ = new string[](2);
+        aggregatorIds_[0] = "1";
+        aggregatorIds_[1] = "2";
+
+        bool[] memory statuses_ = new bool[](2);
+        statuses_[0] = false;
+        statuses_[1] = true;
+
+        vm.startPrank(owner);
+        delegationMetaSwapAdapter.updateAllowedAggregatorIds(aggregatorIds_, statuses_);
+        vm.stopPrank();
+
+        bytes32 aggregator1Hash_ = keccak256(abi.encode("1"));
+        bytes32 aggregator2Hash_ = keccak256(abi.encode("2"));
+        assertFalse(delegationMetaSwapAdapter.isAggregatorAllowed(aggregator1Hash_));
+        assertTrue(delegationMetaSwapAdapter.isAggregatorAllowed(aggregator2Hash_));
+    }
+
+    /// @notice Verifies that non-owners cannot call updateAllowedAggregatorIds.
+    function test_revert_updateAllowedAggregatorIds_ifNotOwner() public {
+        _setUpMockContracts();
+
+        string[] memory aggregatorIds_ = new string[](1);
+        aggregatorIds_[0] = "randomId";
+        bool[] memory statuses_ = new bool[](1);
+        statuses_[0] = true;
+
+        vm.startPrank(address(subVault.deleGator));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(subVault.deleGator)));
+        delegationMetaSwapAdapter.updateAllowedAggregatorIds(aggregatorIds_, statuses_);
+        vm.stopPrank();
+    }
+
+    /// @notice Verifies that updateAllowedAggregatorIds reverts if array lengths mismatch.
+    function test_revert_updateAllowedAggregatorIds_arrayLengthMismatch() public {
+        _setUpMockContracts();
+
+        string[] memory aggregatorIds_ = new string[](2);
+        aggregatorIds_[0] = "A1";
+        aggregatorIds_[1] = "A2";
+
+        bool[] memory statuses_ = new bool[](1);
+        statuses_[0] = true;
+
+        vm.startPrank(owner);
+        vm.expectRevert(abi.encodeWithSelector(DelegationMetaSwapAdapter.InputLengthsMismatch.selector));
+        delegationMetaSwapAdapter.updateAllowedAggregatorIds(aggregatorIds_, statuses_);
+        vm.stopPrank();
+    }
+
+    /// @notice Ensures that calling `swapTokens` externally reverts with `NotSelf()`.
+    function test_revert_swapTokens_ifNotSelf() public {
+        _setUpMockContracts();
+        vm.startPrank(address(subVault.deleGator));
+        vm.expectRevert(DelegationMetaSwapAdapter.NotSelf.selector);
+        delegationMetaSwapAdapter.swapTokens("test-aggregator-id", tokenA, tokenB, address(vault.deleGator), 1 ether, 0, hex"");
+        vm.stopPrank();
+    }
+
+    // @notice Tests the onlyDelegationManager modifier in executeFromExecutor
+    function test_revert_executeFromExecutor_ifNotDelegationManager() public {
+        _setUpMockContracts();
+        vm.startPrank(address(subVault.deleGator));
+        vm.expectRevert(DelegationMetaSwapAdapter.NotDelegationManager.selector);
+        ModeCode modeCode_;
+        delegationMetaSwapAdapter.executeFromExecutor(modeCode_, hex"");
+        vm.stopPrank();
+    }
+
+    /**
+     * @dev Deploys and configures a MetaSwapMock that can be used to test the delegationMetaSwapAdapter contract
+     */
+    function _setUpMockContracts() internal {
+        _setUpMockContractsEth(false, false);
+    }
+
+    /**
+     * @dev Deploys and configures a MetaSwapMock that can be used to test the delegationMetaSwapAdapter contract
+     * @dev Allows to specify the use of eth for the tokenFrom or tokenTo
+     */
+    function _setUpMockContractsEth(bool _useEthFrom, bool _useEthTo) internal {
+        vault = users.alice;
+        subVault = users.bob;
+
+        tokenA = _useEthFrom ? BasicERC20(address(0)) : new BasicERC20(owner, "TokenA", "TokenA", 0);
+        tokenB = _useEthTo ? BasicERC20(address(0)) : new BasicERC20(owner, "TokenB", "TokenB", 0);
+        vm.label(address(tokenA), "TokenA");
+        vm.label(address(tokenB), "TokenB");
+
+        metaSwapMock = IMetaSwap(address(new MetaSwapMock(IERC20(tokenA), IERC20(tokenB))));
+
+        delegationMetaSwapAdapter =
+            new DelegationMetaSwapAdapter(owner, IDelegationManager(address(delegationManager)), metaSwapMock);
+
+        vm.startPrank(owner);
+
+        if (!_useEthFrom) {
+            tokenA.mint(address(vault.deleGator), 100 ether);
+            tokenA.mint(address(metaSwapMock), 1000 ether);
+        }
+        if (!_useEthTo) {
+            tokenB.mint(address(vault.deleGator), 100 ether);
+            tokenB.mint(address(metaSwapMock), 1000 ether);
+        }
+
+        vm.stopPrank();
+
+        vm.deal(address(metaSwapMock), 1000 ether);
+
+        _updateAllowedTokens();
+
+        _whiteListAggregatorId(aggregatorId);
+
+        swapDataTokenAtoTokenB =
+            abi.encode(IERC20(address(tokenA)), IERC20(address(tokenB)), 1 ether, 1 ether, hex"", uint256(0), address(0), true);
+    }
+}
+
+/**
+ * @title DelegationMetaSwapAdapterForkTest
+ * @notice These tests run on a fork. Note that the fork creation is performed
+ *  as the very first step in setUp.
+ */
+contract DelegationMetaSwapAdapterForkTest is DelegationMetaSwapAdapterBaseTest {
+    ////////////////////////
+    // MetaSwap + Linea mainnet fork section
+    ////////////////////////
+    uint256 mainnetFork;
+    IDelegationManager constant DELEGATION_MANAGER_FORK = IDelegationManager(0x739309deED0Ae184E66a427ACa432aE1D91d022e);
+    HybridDeleGator constant HYBRID_DELEGATOR_IMPL_FORK = HybridDeleGator(payable(0xf4E57F579ad8169D0d4Da7AedF71AC3f83e8D2b4));
+    EntryPoint constant ENTRY_POINT_FORK = EntryPoint(payable(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
+    IMetaSwap constant META_SWAP_FORK = IMetaSwap(0x9dDA6Ef3D919c9bC8885D5560999A3640431e8e6);
+    bytes public constant API_DATA_ERC20_TO_ERC20 =
+        hex"5f5755290000000000000000000000000000000000000000000000000000000000000080000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000136f70656e4f6365616e46656544796e616d6963000000000000000000000000000000000000000000000000000000000000000000000000000000000000001c80000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000000000000000000000000000000000003b9aca000000000000000000000000000000000000000000000000000000000039ece309000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000008591cb0000000000000000000000001f3c3f0243d06a0353abcb066be9140747aeb8c900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000001b4490411a32000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a99000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a990000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b9509330000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000000000000000000000000000000000003a6fc8f3000000000000000000000000000000000000000000000000000000003ba116320000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ef53a4bd0e16ccc9116770a41c4bd3ad1147bd4f00000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004c0000000000000000000000000000000000000000000000000000000000000072000000000000000000000000000000000000000000000000000000000000008400000000000000000000000000000000000000000000000000000000000000b400000000000000000000000000000000000000000000000000000000000000e40000000000000000000000000000000000000000000000000000000000000114000000000000000000000000000000000000000000000000000000000000015e0000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb0000000000000000000000003cb104f044db23d6513f2a6100a1997fa5e3f58700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000023c34600000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002e176211869ca2b568f2a7d4ee941e073a821ee1ff000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000170000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104576188040000000000000000000000005615a7b1619980f7d6b5e7f69f3dc093dfe0c95c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000017d78400000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003f45e5f26451cdb01b0fa1f8582e0aad9a6f27c218176211869ca2b568f2a7d4ee941e073a821ee1ff0001f4e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001a49f865422000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f00000000000000000000000000000008000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000064d1660f99000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000101c6e1e717f13fb351c0b51ffaa8839034f474d000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008d58ee2d23f7920ea32e534aad8d6753c88bc01a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006493316212000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b4000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002449f865422000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000000000000000000000000000000e000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb0000000000000000000000008e80016b025c89a6a270b399f5ebfb734be58ada00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002ee5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000003aab2285ddcddad8edf438c1bab47e1a9d05a9b40000170000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002449f865422000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f00000000000000000000000000000002000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb000000000000000000000000f11bb479dc3daffe63989b6b95f6c119225dac2800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002ee5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000fa3aab2285ddcddad8edf438c1bab47e1a9d05a9b400001e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002449f865422000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f00000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb000000000000000000000000a22206521a460aa6b21a089c3b48ffd0c79d5fd500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002ee5d7c2a44ffddf6b295a15c148167daaaf5cf34f0001f43aab2285ddcddad8edf438c1bab47e1a9d05a9b40000220000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000003e451a743160000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b400000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000038000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000064d1660f990000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b4000000000000000000000000ed9e3f98bbed560e66b89aac922e29d4596a9642000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000ed9e3f98bbed560e66b89aac922e29d4596a964200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c47dc203820000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b4000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b9300000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a99000000000000000000000000922164bbbd36acf9e854acbbf32facc949fcaeef0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000648a6a1e85000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000922164bbbd36acf9e854acbbf32facc949fcaeef000000000000000000000000000000000000000000000000000000003ba1163200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001a49f865422000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b9300000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000064d1660f99000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b950933000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046";
+
+    bytes public constant API_DATA_NATIVE_TO_ERC20 =
+        hex"5f575529000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000136b796265725377617046656544796e616d69630000000000000000000000000000000000000000000000000000000000000000000000000000000000000012600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000000000000000000000000000dc1a09f859b2000000000000000000000000000000000000000000000000000000000009d7ae8560000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000001f161421c8e0000000000000000000000000001f3c3f0243d06a0353abcb066be9140747aeb8c900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001124e21fd0e900000000000000000000000000000000000000000000000000000000000000200000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000ca00000000000000000000000000000000000000000000000000000000000000ea00000000000000000000000000000000000000000000000000000000000000be0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b95093300000000000000000000000000000000000000000000000000000000067b8a3780000000000000000000000000000000000000000000000000000000000000b800000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000092000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004063407a490000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca30000000000000000000000001947b87d35e9f1cd53cede1ad6f7be44c12212b8000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b9300000000000000000000000000000000000000000000000000b014d4c6ae2800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000002e0000000000000000000000000000000000000000000000000000000000000004063407a490000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca3000000000000000000000000a22206521a460aa6b21a089c3b48ffd0c79d5fd5000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b400000000000000000000000000000000000000000000000002103e7e540a780000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004048d318020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca30000000000000000000000001d6cbd5ab95fcc04edde14abfa8d363adf4ead000000000000000000000000003aab2285ddcddad8edf438c1bab47e1a9d05a9b4000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff0000000000000000000000000000000000000000000000000000000000065d7700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004063407a490000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca30000000000000000000000005856edf9212bdcec74301ec78afc573b62d6a283000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b9300000000000000000000000000000000000000000000000000000000181b821c00000000000000000000000000000000000000000000000000000001000276a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000004063407a490000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca3000000000000000000000000586733678b9ac9da43dd7cb83bbb41d23677dfc3000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff00000000000000000000000000000000000000000000000000b014d4c6ae280000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004063407a490000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca3000000000000000000000000142ec7a60d2b339287c79969b1f3bfb1d81af27f000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000000000000000000000000000000000000808a2b400000000000000000000000000000000000000000000000000000001000276a4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004048d318020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000f4a1d7fdf4890be35e71f3e0bbc4a0ec377eca30000000000000000000000008611456f845293edd3f5788277f00f7c05ccc291000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000000000000000000000000000a513877a434580000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000a87000000000000000000000000a0b1a92a000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b95093300000000000000000000000000000000000000000000000000dc1a09f859b2000000000000000000000000000000000000000000000000000000000009d7ae856000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002297b22536f75726365223a226d6574616d61736b222c22416d6f756e74496e555344223a22323730362e37323232353435353439313735222c22416d6f756e744f7574555344223a22323730362e36373337303135323137313633222c22526566657272616c223a22222c22466c616773223a302c22416d6f756e744f7574223a2232363935393937373337222c2254696d657374616d70223a313734303135323532302c22496e74656772697479496e666f223a7b224b65794944223a2231222c225369676e6174757265223a225a304e6b4170457455546b6f5a59586b4930396e3950616473515a6d50586b4c5433556e7a4b6b504d2b4e626a795957735454614b613358586e6e67686371422b57306d3353484b55776468446d51546a4a63375646554862417736316f4953384e73537952715037304c347645545a4b5566535567336f507663524449396b442f45325637565865626f413968385a3142385a70703148436a6c517a364a77434970617770723839746f642f486c79447245416f446a53716c65306c50684e36557767355758674755364e54624f7142794d69673870466f4a4f5a756662314738737a3841374878672b646a397455452f615343667738443847577744785778694942687858515645556568544e6c52737932447a3635576e39325a4b78646766536c4b7634314469675659494d4a68374662456c7a5750425a383639764b2b5255796f426153583130666e5a6d6e4743414a48413d3d227d7d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff";
+
+    bytes public constant API_DATA_ERC20_TO_NATIVE =
+        hex"5f5755290000000000000000000000000000000000000000000000000000000000000080000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000136f70656e4f6365616e46656544796e616d6963000000000000000000000000000000000000000000000000000000000000000000000000000000000000001140000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b930000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000004f388ae029a1c8d0000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000b6acb789f1c6f0000000000000000000000001f3c3f0243d06a0353abcb066be9140747aeb8c90000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100490411a32000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a99000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000a219439258ca9da29e9cc4ce5596924745e12b93000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a990000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b9509330000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000004feb904c59c70bc0000000000000000000000000000000000000000000000000518d1b147081f720000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ef53a4bd0e16ccc9116770a41c4bd3ad1147bd4f00000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000280000000000000000000000000000000000000000000000000000000000000058000000000000000000000000000000000000000000000000000000000000008800000000000000000000000000000000000000000000000000000000000000aa00000000000000000000000000000000000000000000000000000000000000bc000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb000000000000000000000000efd5ec2cc043e3bd3c840f7998cc42ee712700ba0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002ea219439258ca9da29e9cc4ce5596924745e12b93000064176211869ca2b568f2a7d4ee941e073a821ee1ff00001e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002449f865422000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff0000000000000000000000000000000f000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104e5b07cdb0000000000000000000000003cb104f044db23d6513f2a6100a1997fa5e3f58700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002e176211869ca2b568f2a7d4ee941e073a821ee1ff000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f0000170000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000002449f865422000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff00000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000104576188040000000000000000000000005615a7b1619980f7d6b5e7f69f3dc093dfe0c95c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000dec876911cbe9428265af0d12132c52ee8642a9900000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003f45e5f26451cdb01b0fa1f8582e0aad9a6f27c218176211869ca2b568f2a7d4ee941e073a821ee1ff0001f4e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001649f865422000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000000000010000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000242e1a7d4d00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000648a6a1e85000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000922164bbbd36acf9e854acbbf32facc949fcaeef0000000000000000000000000000000000000000000000000518d1b147081f7200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001a49f865422000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000064d1660f99000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000000a2854fbbd9b3ef66f17d47284e7f899b9509330000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f5";
+
+    function setUp() public override {
+        // *** Create the fork before any other setup runs ***
+        // Note: These tests use linea mainnet and a specific block number
+        // If you desire to change this fork configuration do not forget to update the API_DATA values
+
+        vm.createSelectFork(vm.envString("LINEA_RPC_URL"), 16_100_581);
+
+        super.setUp();
+    }
+
+    /**
+     * @notice Demonstrates a fork-based test on the Linea chain
+     * This test ensures the DelegationMetaSwapAdapter contract can perform an
+     * ERC20 token to ERC20 token swap by delegation on mainnet-fork conditions.
+     */
+    function test_canSwapByDelegationsInForkErc20ToErc20() public {
+        (,, IERC20 tokenFrom_, IERC20 tokenTo_,,) = _setUpForkContracts(API_DATA_ERC20_TO_ERC20);
+
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        uint256 vaultTokenFromBalanceBefore_ = tokenFrom_.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenToBalanceBefore_ = tokenTo_.balanceOf(address(vault.deleGator));
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(API_DATA_ERC20_TO_ERC20, delegations_);
+
+        uint256 vaultTokenFromUsed_ = vaultTokenFromBalanceBefore_ - tokenFrom_.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenToObtained_ = tokenTo_.balanceOf(address(vault.deleGator)) - vaultTokenToBalanceBefore_;
+        assertEq(vaultTokenFromUsed_, amountFrom, "Vault should spend the specified amount of tokenFrom");
+        assertGe(vaultTokenToObtained_, amountTo, "Vault should receive the correct amount of tokenTo");
+    }
+
+    /**
+     * @notice Demonstrates a fork-based test on the Linea chain
+     * This test ensures the DelegationMetaSwapAdapter contract can perform an
+     * Native Token to ERC20 token swap by delegation on mainnet-fork conditions.
+     */
+    function test_canSwapByDelegationsInForkNativeTokenToErc20() public {
+        (,,, IERC20 tokenTo_,,) = _setUpForkContracts(API_DATA_NATIVE_TO_ERC20);
+
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        // Record vault's ETH and tokenB balances before swap.
+        uint256 vaultEthBalanceBefore = address(vault.deleGator).balance;
+        uint256 vaultTokenBBalanceBefore = tokenTo_.balanceOf(address(vault.deleGator));
+
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(API_DATA_NATIVE_TO_ERC20, delegations_);
+
+        // Calculate the change in balances.
+        uint256 vaultEthUsed = vaultEthBalanceBefore - address(vault.deleGator).balance;
+        uint256 vaultTokenBObtained = tokenB.balanceOf(address(vault.deleGator)) - vaultTokenBBalanceBefore;
+        assertEq(vaultEthUsed, amountFrom, "Vault should spend the specified amount of ETH");
+        assertGe(vaultTokenBObtained, amountTo, "Vault should receive the correct amount of tokenB");
+    }
+
+    /**
+     * @notice Demonstrates a fork-based test on the Linea chain
+     * This test ensures the DelegationMetaSwapAdapter contract can perform an
+     * ERC20 token to Native Token swap by delegation on mainnet-fork conditions.
+     */
+    function test_canSwapByDelegationsInForkErc20ToNativeToken() public {
+        (,, IERC20 tokenFrom_,,,) = _setUpForkContracts(API_DATA_ERC20_TO_NATIVE);
+
+        Delegation[] memory delegations_ = new Delegation[](2);
+
+        Delegation memory vaultDelegation_ = _getVaultDelegation();
+        Delegation memory subVaultDelegation_ = _getSubVaultDelegation(EncoderLib._getDelegationHash(vaultDelegation_));
+        delegations_[1] = vaultDelegation_;
+        delegations_[0] = subVaultDelegation_;
+
+        uint256 vaultTokenFromBalanceBefore_ = tokenFrom_.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenToBalanceBefore_ = address(vault.deleGator).balance;
+
+        vm.prank(address(subVault.deleGator));
+        delegationMetaSwapAdapter.swapByDelegation(API_DATA_ERC20_TO_NATIVE, delegations_);
+
+        uint256 vaultTokenFromUsed_ = vaultTokenFromBalanceBefore_ - tokenFrom_.balanceOf(address(vault.deleGator));
+        uint256 vaultTokenToObtained_ = address(vault.deleGator).balance - vaultTokenToBalanceBefore_;
+        assertEq(vaultTokenFromUsed_, amountFrom, "Vault should spend the specified amount of token from");
+        assertGe(vaultTokenToObtained_, amountTo, "Vault should receive the correct amount of tokenTo");
+    }
+
+    /**
+     * @dev Overrides and configures the fork contracts that can be used to test the delegationMetaSwapAdapter contract
+     */
+    function _setUpForkContracts(bytes memory _apiData)
+        private
+        returns (
+            string memory aggregatorId_,
+            bytes memory swapData_,
+            IERC20 tokenFrom_,
+            IERC20 tokenTo_,
+            uint256 amountFrom_,
+            uint256 amountTo_
+        )
+    {
+        // Overriding values
+        entryPoint = ENTRY_POINT_FORK;
+        delegationMetaSwapAdapter = new DelegationMetaSwapAdapter(owner, DELEGATION_MANAGER_FORK, META_SWAP_FORK);
+        delegationManager = DelegationManager(address(DELEGATION_MANAGER_FORK));
+        hybridDeleGatorImpl = HYBRID_DELEGATOR_IMPL_FORK;
+
+        users = _createUsers();
+        vault = users.alice;
+        subVault = users.bob;
+
+        (aggregatorId_, tokenFrom_, amountFrom_, swapData_) = _decodeApiData(_apiData);
+
+        _whiteListAggregatorId(aggregatorId_);
+
+        (, tokenTo_,, amountTo_) = _decodeApiSwapData(swapData_);
+        tokenA = BasicERC20(address(tokenFrom_));
+        tokenB = BasicERC20(address(tokenTo_));
+        amountFrom = amountFrom_;
+        amountTo = amountTo_;
+
+        _updateAllowedTokens();
+
+        if (address(tokenFrom_) != address(0)) {
+            deal(address(tokenFrom_), address(vault.deleGator), 1_000_000 ether);
+        }
+
+        return (aggregatorId_, swapData_, tokenFrom_, tokenTo_, amountFrom_, amountTo_);
+    }
+}
+
+/**
+ * @title MetaSwapMock
+ * @notice A mock aggregator for testing. Swaps `tokenA` <-> `tokenB` at a 1:1 rate.
+ */
+contract MetaSwapMock {
+    using SafeERC20 for IERC20;
+
+    error InvalidValueTransfer();
+
+    IERC20 public tokenA;
+    IERC20 public tokenB;
+
+    /**
+     * @notice Initializes the mock with two tokens to swap between.
+     */
+    constructor(IERC20 _tokenA, IERC20 _tokenB) {
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+    }
+
+    /**
+     * @notice Swaps from `tokenFrom` to the other token at a 1:1 ratio, purely for testing.
+     * @dev Pulls `_amount` from the caller, then sends the alternate token back to the caller.
+     */
+    function swap(string calldata, IERC20 _tokenFrom, uint256 _amount, bytes calldata) external payable {
+        require(_tokenFrom == tokenA || _tokenFrom == tokenB, "MetaSwapMock:invalid-token-from");
+
+        if (address(_tokenFrom) != address(0)) {
+            _tokenFrom.safeTransferFrom(msg.sender, address(this), _amount);
+        }
+
+        IERC20 tokenTo_ = _tokenFrom == tokenA ? tokenB : tokenA;
+
+        if (address(tokenTo_) == address(0)) {
+            (bool success_,) = msg.sender.call{ value: _amount }("");
+            if (!success_) revert InvalidValueTransfer();
+            require(success_, "MetaSwapMock:invalid-value-transfer");
+        } else {
+            tokenTo_.safeTransfer(msg.sender, _amount);
+        }
+    }
+}

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -444,9 +444,9 @@ abstract contract BaseTest is Test {
         vm.label(address(user_.deleGator), string.concat(_name, " DeleGator"));
     }
 
-    ////////////////////////////// Private //////////////////////////////
+    ////////////////////////////// Internal //////////////////////////////
 
-    function _createUsers() private returns (TestUsers memory users_) {
+    function _createUsers() internal returns (TestUsers memory users_) {
         users_.alice = createUser("Alice");
         users_.bob = createUser("Bob");
         users_.carol = createUser("Carol");


### PR DESCRIPTION
### **What?**

- Added Delegation MetaSwap Adapter: This contract works as an intermediary helper that can be used to perform swaps on MetaSwap using delegations.

### **Why?**

- Currently, DEXs don't enable the Delegation Framework to accept delegations to subtract the token from the caller's account. This adapter allows the use of delegations for swaps.

### **How?**

- A delegation is created using the DelegationMetaSwapAdapter as the delegate. The DelegationMetaSwapAdapter is triggered using a function called `swapByDelegation(bytes calldata _apiData, Delegation[] memory _delegations)` the user passes the delegation and the apiData generated by the SwapAPI 
