### PR TITLE
Add Exact Calldata Batch Enforcer

### DIFF
--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -19,6 +19,7 @@ import { ERC20PeriodTransferEnforcer } from "../src/enforcers/ERC20PeriodTransfe
 import { ERC721BalanceGteEnforcer } from "../src/enforcers/ERC721BalanceGteEnforcer.sol";
 import { ERC721TransferEnforcer } from "../src/enforcers/ERC721TransferEnforcer.sol";
 import { ERC1155BalanceGteEnforcer } from "../src/enforcers/ERC1155BalanceGteEnforcer.sol";
+import { ExactCalldataBatchEnforcer } from "../src/enforcers/ExactCalldataBatchEnforcer.sol";
 import { ExactCalldataEnforcer } from "../src/enforcers/ExactCalldataEnforcer.sol";
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
@@ -99,6 +100,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new ERC1155BalanceGteEnforcer{ salt: salt }());
         console2.log("ERC1155BalanceGteEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new ExactCalldataBatchEnforcer{ salt: salt }());
+        console2.log("ExactCalldataBatchEnforcer: %s", deployedAddress);
 
         deployedAddress = address(new ExactCalldataEnforcer{ salt: salt }());
         console2.log("ExactCalldataEnforcer: %s", deployedAddress);

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode, Execution } from "../utils/Types.sol";
+
+/**
+ * @title ExactCalldataBatchEnforcer
+ * @notice Ensures that the provided batch execution calldata matches exactly the expected calldata for each execution.
+ * @dev This caveat enforcer operates only in batch execution mode.
+ */
+contract ExactCalldataBatchEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Validates that each execution's calldata in the batch matches the expected calldata.
+     * @param _terms The encoded expected Executions.
+     * @param _mode The execution mode, which must be batch.
+     * @param _executionCallData The batch execution calldata.
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32,
+        address,
+        address
+    )
+        public
+        pure
+        override
+        onlyBatchExecutionMode(_mode)
+    {
+        Execution[] calldata executions_ = _executionCallData.decodeBatch();
+        Execution[] memory termsExecutions_ = getTermsInfo(_terms);
+
+        // Validate that the number of executions matches the number of expected calldata
+        require(executions_.length == termsExecutions_.length, "ExactCalldataBatchEnforcer:invalid-batch-size");
+
+        // Check each execution's calldata matches exactly
+        for (uint256 i = 0; i < executions_.length; i++) {
+            require(
+                keccak256(termsExecutions_[i].callData) == keccak256(executions_[i].callData),
+                "ExactCalldataBatchEnforcer:invalid-calldata"
+            );
+        }
+    }
+
+    /**
+     * @notice Extracts the expected executions from the provided terms.
+     * @param _terms The encoded expected Executions.
+     * @return executions_ Array of expected Executions.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (Execution[] memory executions_) {
+        executions_ = _terms.decodeBatch();
+    }
+}

--- a/test/enforcers/ExactCalldataBatchEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataBatchEnforcer.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import "forge-std/Test.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+
+import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { ExactCalldataBatchEnforcer } from "../../src/enforcers/ExactCalldataBatchEnforcer.sol";
+import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+
+contract ExactCalldataBatchEnforcerTest is CaveatEnforcerBaseTest {
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// State //////////////////////////////
+    ExactCalldataBatchEnforcer public exactCalldataBatchEnforcer;
+    BasicERC20 public basicCF20;
+    ModeCode public batchMode = ModeLib.encodeSimpleBatch();
+    ModeCode public singleMode = ModeLib.encodeSimpleSingle();
+
+    ////////////////////////////// Setup //////////////////////////////
+    function setUp() public override {
+        super.setUp();
+        exactCalldataBatchEnforcer = new ExactCalldataBatchEnforcer();
+        vm.label(address(exactCalldataBatchEnforcer), "Exact Calldata Batch Enforcer");
+        basicCF20 = new BasicERC20(address(users.alice.deleGator), "TestToken1", "TestToken1", 100 ether);
+    }
+
+    ////////////////////////////// Unit Tests //////////////////////////////
+
+    /// @notice Test that the enforcer passes when all calldata in the batch matches exactly.
+    function test_exactCalldataMatches() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+
+        // First execution: transfer tokens
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Second execution: transfer more tokens
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms that match exactly
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when any calldata in the batch doesn't match.
+    function test_exactCalldataFailsWhenMismatch() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+
+        // First execution: transfer tokens
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Second execution: transfer more tokens
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms with a mismatch in the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(3 ether))
+        });
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-calldata");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when batch size doesn't match.
+    function test_batchSizeMismatch() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms with only one execution
+        Execution[] memory termsExecutions_ = new Execution[](1);
+        termsExecutions_[0] = executions_[0];
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-batch-size");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when single mode is used.
+    function test_singleModeReverts() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", singleMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    ////////////////////////////// Integration Tests //////////////////////////////
+
+    /// @notice Integration test: the enforcer allows a batch of token transfers when calldata matches exactly.
+    function test_integration_AllowsBatchTokenTransfers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms that match exactly
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactCalldataBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances changed correctly
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_ + 1 ether);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_ + 2 ether);
+    }
+
+    /// @notice Integration test: the enforcer blocks batch execution when any calldata doesn't match.
+    function test_integration_BlocksBatchWhenCalldataDiffers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with a mismatch in the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(3 ether))
+        });
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactCalldataBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-calldata");
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances remain unchanged
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_);
+    }
+
+    ////////////////////////////// Helper Functions //////////////////////////////
+
+    /// @notice Helper function to encode terms for the batch enforcer
+    function _encodeTerms(Execution[] memory _executions) internal pure returns (bytes memory) {
+        return ExecutionLib.encodeBatch(_executions);
+    }
+
+    ////////////////////////////// Internal Overrides //////////////////////////////
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(exactCalldataBatchEnforcer));
+    }
+}


### PR DESCRIPTION
### **What?**

- A new Exact calldata enforcer that can be used to compare and validate an exact match between the terms calldata for batch executions.

### **Why?**

- This enforcer would be useful to enforcer specific calldata execution in a batch call.

### **How?**

- The delegator encodes an array of `Execution` types and the `ExactCalldataEnforcer` enforces the calldata of each execution must match.
