### PR TITLE
Add Exact Execution Single & Batch Enforcer

### DIFF
--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -21,6 +21,7 @@ import { ERC721TransferEnforcer } from "../src/enforcers/ERC721TransferEnforcer.
 import { ERC1155BalanceGteEnforcer } from "../src/enforcers/ERC1155BalanceGteEnforcer.sol";
 import { ExactCalldataEnforcer } from "../src/enforcers/ExactCalldataEnforcer.sol";
 import { ExactExecutionBatchEnforcer } from "../src/enforcers/ExactExecutionBatchEnforcer.sol";
+import { ExactExecutionEnforcer } from "../src/enforcers/ExactExecutionEnforcer.sol";
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
 import { NativeBalanceGteEnforcer } from "../src/enforcers/NativeBalanceGteEnforcer.sol";
@@ -106,6 +107,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new ExactExecutionBatchEnforcer{ salt: salt }());
         console2.log("ExactExecutionBatchEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new ExactExecutionEnforcer{ salt: salt }());
+        console2.log("ExactExecutionEnforcer: %s", deployedAddress);
 
         deployedAddress = address(new IdEnforcer{ salt: salt }());
         console2.log("IdEnforcer: %s", deployedAddress);

--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -20,6 +20,7 @@ import { ERC721BalanceGteEnforcer } from "../src/enforcers/ERC721BalanceGteEnfor
 import { ERC721TransferEnforcer } from "../src/enforcers/ERC721TransferEnforcer.sol";
 import { ERC1155BalanceGteEnforcer } from "../src/enforcers/ERC1155BalanceGteEnforcer.sol";
 import { ExactCalldataEnforcer } from "../src/enforcers/ExactCalldataEnforcer.sol";
+import { ExactExecutionBatchEnforcer } from "../src/enforcers/ExactExecutionBatchEnforcer.sol";
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
 import { NativeBalanceGteEnforcer } from "../src/enforcers/NativeBalanceGteEnforcer.sol";
@@ -102,6 +103,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new ExactCalldataEnforcer{ salt: salt }());
         console2.log("ExactCalldataEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new ExactExecutionBatchEnforcer{ salt: salt }());
+        console2.log("ExactExecutionBatchEnforcer: %s", deployedAddress);
 
         deployedAddress = address(new IdEnforcer{ salt: salt }());
         console2.log("IdEnforcer: %s", deployedAddress);

--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -21,6 +21,7 @@ import { ERC721TransferEnforcer } from "../src/enforcers/ERC721TransferEnforcer.
 import { ERC1155BalanceGteEnforcer } from "../src/enforcers/ERC1155BalanceGteEnforcer.sol";
 import { ExactCalldataEnforcer } from "../src/enforcers/ExactCalldataEnforcer.sol";
 import { ExactExecutionBatchEnforcer } from "../src/enforcers/ExactExecutionBatchEnforcer.sol";
+import { ExactCalldataBatchEnforcer } from "../src/enforcers/ExactCalldataBatchEnforcer.sol";
 import { ExactExecutionEnforcer } from "../src/enforcers/ExactExecutionEnforcer.sol";
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
@@ -104,6 +105,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new ExactCalldataEnforcer{ salt: salt }());
         console2.log("ExactCalldataEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new ExactCalldataBatchEnforcer{ salt: salt }());
+        console2.log("ExactCalldataBatchEnforcer: %s", deployedAddress);
 
         deployedAddress = address(new ExactExecutionBatchEnforcer{ salt: salt }());
         console2.log("ExactExecutionBatchEnforcer: %s", deployedAddress);

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode, Execution } from "../utils/Types.sol";
+
+/**
+ * @title ExactCalldataBatchEnforcer
+ * @notice Ensures that the provided batch execution calldata matches exactly the expected calldata for each execution.
+ * @dev This caveat enforcer operates only in batch execution mode.
+ */
+contract ExactCalldataBatchEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Validates that each execution's calldata in the batch matches the expected calldata.
+     * @param _terms The encoded expected Executions.
+     * @param _mode The execution mode, which must be batch.
+     * @param _executionCallData The batch execution calldata.
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32,
+        address,
+        address
+    )
+        public
+        pure
+        override
+        onlyBatchExecutionMode(_mode)
+    {
+        Execution[] calldata executions_ = _executionCallData.decodeBatch();
+        Execution[] memory termsExecutions_ = getTermsInfo(_terms);
+
+        // Validate that the number of executions matches the number of expected calldata
+        require(executions_.length == termsExecutions_.length, "ExactCalldataBatchEnforcer:invalid-batch-size");
+
+        // Check each execution's calldata matches exactly
+        for (uint256 i = 0; i < executions_.length; i++) {
+            require(
+                keccak256(termsExecutions_[i].callData) == keccak256(executions_[i].callData),
+                "ExactCalldataBatchEnforcer:invalid-calldata"
+            );
+        }
+    }
+
+    /**
+     * @notice Extracts the expected executions from the provided terms.
+     * @param _terms The encoded expected Executions.
+     * @return executions_ Array of expected Executions.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (Execution[] memory executions_) {
+        executions_ = _terms.decodeBatch();
+    }
+}

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode, Execution } from "../utils/Types.sol";
+
+/**
+ * @title ExactExecutionBatchEnforcer
+ * @notice Ensures that each execution in the batch matches exactly with the expected execution (target, value, and calldata).
+ * @dev This caveat enforcer operates only in batch execution mode.
+ */
+contract ExactExecutionBatchEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Validates that each execution in the batch matches exactly with the expected execution.
+     * @param _terms The encoded expected Executions.
+     * @param _mode The execution mode, which must be batch.
+     * @param _executionCallData The batch execution calldata.
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32,
+        address,
+        address
+    )
+        public
+        pure
+        override
+        onlyBatchExecutionMode(_mode)
+    {
+        Execution[] calldata executions_ = _executionCallData.decodeBatch();
+        Execution[] memory termsExecutions_ = getTermsInfo(_terms);
+
+        // Validate that the number of executions matches
+        require(executions_.length == termsExecutions_.length, "ExactExecutionBatchEnforcer:invalid-batch-size");
+
+        // Check each execution matches exactly (target, value, and calldata)
+        for (uint256 i = 0; i < executions_.length; i++) {
+            require(
+                termsExecutions_[i].target == executions_[i].target && termsExecutions_[i].value == executions_[i].value
+                    && keccak256(termsExecutions_[i].callData) == keccak256(executions_[i].callData),
+                "ExactExecutionBatchEnforcer:invalid-execution"
+            );
+        }
+    }
+
+    /**
+     * @notice Extracts the expected executions from the provided terms.
+     * @param _terms The encoded expected Executions.
+     * @return executions_ Array of expected Executions.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (Execution[] memory executions_) {
+        executions_ = _terms.decodeBatch();
+    }
+}

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -44,14 +44,11 @@ contract ExactExecutionBatchEnforcer is CaveatEnforcer {
         // Validate that the number of executions matches
         require(executions_.length == termsExecutions_.length, "ExactExecutionBatchEnforcer:invalid-batch-size");
 
-        // Check each execution matches exactly (target, value, and calldata)
-        for (uint256 i = 0; i < executions_.length; i++) {
-            require(
-                termsExecutions_[i].target == executions_[i].target && termsExecutions_[i].value == executions_[i].value
-                    && keccak256(termsExecutions_[i].callData) == keccak256(executions_[i].callData),
-                "ExactExecutionBatchEnforcer:invalid-execution"
-            );
-        }
+        // Encode both sets of executions and compare the hashes
+        require(
+            keccak256(abi.encode(executions_)) == keccak256(abi.encode(termsExecutions_)),
+            "ExactExecutionBatchEnforcer:invalid-execution"
+        );
     }
 
     /**

--- a/src/enforcers/ExactExecutionEnforcer.sol
+++ b/src/enforcers/ExactExecutionEnforcer.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode, Execution } from "../utils/Types.sol";
+
+/**
+ * @title ExactExecutionEnforcer
+ * @notice Ensures that the provided execution matches exactly with the expected execution (target, value, and calldata).
+ * @dev This caveat enforcer operates only in single execution mode.
+ */
+contract ExactExecutionEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Validates that the execution matches exactly with the expected execution.
+     * @param _terms The encoded expected Execution.
+     * @param _mode The execution mode, which must be single.
+     * @param _executionCallData The execution calldata.
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32,
+        address,
+        address
+    )
+        public
+        pure
+        override
+        onlySingleExecutionMode(_mode)
+    {
+        // Decode execution data
+        (address execTarget_, uint256 execValue_, bytes calldata execCallData_) = _executionCallData.decodeSingle();
+
+        require(
+            address(bytes20(_terms[0:20])) == execTarget_ && uint256(bytes32(_terms[20:52])) == execValue_
+                && keccak256(_terms[52:]) == keccak256(execCallData_),
+            "ExactExecutionEnforcer:invalid-execution"
+        );
+    }
+
+    /**
+     * @notice Extracts the expected execution from the provided terms.
+     * @param _terms The encoded expected Execution.
+     * @return execution_ The expected Execution.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (Execution memory execution_) {
+        (execution_.target, execution_.value, execution_.callData) = _terms.decodeSingle();
+    }
+}

--- a/test/enforcers/ExactCalldataBatchEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataBatchEnforcer.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import "forge-std/Test.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+
+import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { ExactCalldataBatchEnforcer } from "../../src/enforcers/ExactCalldataBatchEnforcer.sol";
+import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+
+contract ExactCalldataBatchEnforcerTest is CaveatEnforcerBaseTest {
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// State //////////////////////////////
+    ExactCalldataBatchEnforcer public exactCalldataBatchEnforcer;
+    BasicERC20 public basicCF20;
+    ModeCode public batchMode = ModeLib.encodeSimpleBatch();
+    ModeCode public singleMode = ModeLib.encodeSimpleSingle();
+
+    ////////////////////////////// Setup //////////////////////////////
+    function setUp() public override {
+        super.setUp();
+        exactCalldataBatchEnforcer = new ExactCalldataBatchEnforcer();
+        vm.label(address(exactCalldataBatchEnforcer), "Exact Calldata Batch Enforcer");
+        basicCF20 = new BasicERC20(address(users.alice.deleGator), "TestToken1", "TestToken1", 100 ether);
+    }
+
+    ////////////////////////////// Unit Tests //////////////////////////////
+
+    /// @notice Test that the enforcer passes when all calldata in the batch matches exactly.
+    function test_exactCalldataMatches() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+
+        // First execution: transfer tokens
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Second execution: transfer more tokens
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms that match exactly
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when any calldata in the batch doesn't match.
+    function test_exactCalldataFailsWhenMismatch() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+
+        // First execution: transfer tokens
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Second execution: transfer more tokens
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms with a mismatch in the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(3 ether))
+        });
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-calldata");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when batch size doesn't match.
+    function test_batchSizeMismatch() public {
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        // Create terms with only one execution
+        Execution[] memory termsExecutions_ = new Execution[](1);
+        termsExecutions_[0] = executions_[0];
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-batch-size");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when single mode is used.
+    function test_singleModeReverts() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+        exactCalldataBatchEnforcer.beforeHook(terms_, hex"", singleMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    ////////////////////////////// Integration Tests //////////////////////////////
+
+    /// @notice Integration test: the enforcer allows a batch of token transfers when calldata matches exactly.
+    function test_integration_AllowsBatchTokenTransfers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms that match exactly
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactCalldataBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances changed correctly
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_ + 1 ether);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_ + 2 ether);
+    }
+
+    /// @notice Integration test: the enforcer blocks batch execution when any calldata doesn't match.
+    function test_integration_BlocksBatchWhenCalldataDiffers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with a mismatch in the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(3 ether))
+        });
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactCalldataBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        vm.expectRevert("ExactCalldataBatchEnforcer:invalid-calldata");
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances remain unchanged
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_);
+    }
+
+    ////////////////////////////// Helper Functions //////////////////////////////
+
+    /// @notice Helper function to encode terms for the batch enforcer
+    function _encodeTerms(Execution[] memory _executions) internal pure returns (bytes memory) {
+        return ExecutionLib.encodeBatch(_executions);
+    }
+
+    ////////////////////////////// Internal Overrides //////////////////////////////
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(exactCalldataBatchEnforcer));
+    }
+}

--- a/test/enforcers/ExactExecutionBatchEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionBatchEnforcer.t.sol
@@ -24,7 +24,7 @@ contract ExactExecutionBatchEnforcerTest is CaveatEnforcerBaseTest {
     function setUp() public override {
         super.setUp();
         exactExecutionBatchEnforcer = new ExactExecutionBatchEnforcer();
-        vm.label(address(exactExecutionBatchEnforcer), "Exact Calldata Batch Enforcer");
+        vm.label(address(exactExecutionBatchEnforcer), "Exact Execution Batch Enforcer");
         basicCF20 = new BasicERC20(address(users.alice.deleGator), "TestToken1", "TestToken1", 100 ether);
     }
 

--- a/test/enforcers/ExactExecutionBatchEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionBatchEnforcer.t.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { ExactExecutionBatchEnforcer } from "../../src/enforcers/ExactExecutionBatchEnforcer.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { BasicERC20 } from "../utils/BasicERC20.t.sol";
+
+contract ExactExecutionBatchEnforcerTest is CaveatEnforcerBaseTest {
+    ////////////////////////////// State //////////////////////////////
+
+    ExactExecutionBatchEnforcer public exactExecutionBatchEnforcer;
+    BasicERC20 public basicCF20;
+    ModeCode public singleMode = ModeLib.encodeSimpleSingle();
+    ModeCode public batchMode = ModeLib.encodeSimpleBatch();
+
+    ////////////////////////////// Set up //////////////////////////////
+
+    function setUp() public override {
+        super.setUp();
+        exactExecutionBatchEnforcer = new ExactExecutionBatchEnforcer();
+        vm.label(address(exactExecutionBatchEnforcer), "Exact Calldata Batch Enforcer");
+        basicCF20 = new BasicERC20(address(users.alice.deleGator), "TestToken1", "TestToken1", 100 ether);
+    }
+
+    ////////////////////////////// Valid cases //////////////////////////////
+
+    /// @notice Test that the enforcer passes when all executions match exactly.
+    function test_exactExecutionMatches() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    ////////////////////////////// Invalid cases //////////////////////////////
+
+    /// @notice Test that the enforcer reverts when target doesn't match.
+    function test_exactExecutionFailsWhenTargetDiffers() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with a different target for the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(users.bob.deleGator), // Different target
+            value: 0,
+            callData: executions_[1].callData
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionBatchEnforcer:invalid-execution");
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when value doesn't match.
+    function test_exactExecutionFailsWhenValueDiffers() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with a different value for the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: executions_[1].target,
+            value: 1 ether, // Different value
+            callData: executions_[1].callData
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionBatchEnforcer:invalid-execution");
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when calldata doesn't match.
+    function test_exactExecutionFailsWhenCalldataDiffers() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with different calldata for the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: executions_[1].target,
+            value: executions_[1].value,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(3 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionBatchEnforcer:invalid-execution");
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when batch size doesn't match.
+    function test_batchSizeMismatch() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with only one execution
+        Execution[] memory termsExecutions_ = new Execution[](1);
+        termsExecutions_[0] = executions_[0];
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionBatchEnforcer:invalid-batch-size");
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when single mode is used.
+    function test_singleModeReverts() public {
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+        exactExecutionBatchEnforcer.beforeHook(terms_, hex"", singleMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    ////////////////////////////// Integration Tests //////////////////////////////
+
+    /// @notice Integration test: the enforcer allows a batch of token transfers when executions match exactly.
+    function test_integration_AllowsBatchTokenTransfers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms that match exactly
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactExecutionBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances changed correctly
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_ + 1 ether);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_ + 2 ether);
+    }
+
+    /// @notice Integration test: the enforcer blocks batch execution when any execution doesn't match.
+    function test_integration_BlocksBatchWhenExecutionDiffers() public {
+        // Record initial balances
+        uint256 bobInitialBalance_ = basicCF20.balanceOf(address(users.bob.deleGator));
+        uint256 carolInitialBalance_ = basicCF20.balanceOf(address(users.carol.deleGator));
+
+        // Create a batch of executions
+        Execution[] memory executions_ = new Execution[](2);
+        executions_[0] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+        executions_[1] = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.carol.deleGator), uint256(2 ether))
+        });
+
+        // Create terms with a mismatch in the second execution
+        Execution[] memory termsExecutions_ = new Execution[](2);
+        termsExecutions_[0] = executions_[0];
+        termsExecutions_[1] = Execution({
+            target: address(basicCF20),
+            value: 1 ether, // Different value
+            callData: executions_[1].callData
+        });
+
+        bytes memory terms_ = _encodeTerms(termsExecutions_);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactExecutionBatchEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Prepare delegation redemption parameters
+        bytes[] memory permissionContexts_ = new bytes[](1);
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        permissionContexts_[0] = abi.encode(delegations_);
+
+        bytes[] memory executionCallDatas_ = new bytes[](1);
+        executionCallDatas_[0] = ExecutionLib.encodeBatch(executions_);
+
+        // Set up batch mode
+        ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
+        oneBatchMode_[0] = batchMode;
+
+        // Bob redeems the delegation to execute the batch
+        vm.prank(address(users.bob.deleGator));
+        vm.expectRevert("ExactExecutionBatchEnforcer:invalid-execution");
+        delegationManager.redeemDelegations(permissionContexts_, oneBatchMode_, executionCallDatas_);
+
+        // Verify balances remain unchanged
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), bobInitialBalance_);
+        assertEq(basicCF20.balanceOf(address(users.carol.deleGator)), carolInitialBalance_);
+    }
+
+    ////////////////////////////// Helper Functions //////////////////////////////
+
+    /// @notice Helper function to encode terms for the batch enforcer
+    function _encodeTerms(Execution[] memory _executions) internal pure returns (bytes memory) {
+        return ExecutionLib.encodeBatch(_executions);
+    }
+
+    ////////////////////////////// Internal Overrides //////////////////////////////
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(exactExecutionBatchEnforcer));
+    }
+}

--- a/test/enforcers/ExactExecutionEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionEnforcer.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { ExactExecutionEnforcer } from "../../src/enforcers/ExactExecutionEnforcer.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { BasicERC20 } from "../utils/BasicERC20.t.sol";
+
+contract ExactExecutionEnforcerTest is CaveatEnforcerBaseTest {
+    using ModeLib for ModeCode;
+
+    ////////////////////////////// State //////////////////////////////
+    ExactExecutionEnforcer public exactExecutionEnforcer;
+    BasicERC20 public basicCF20;
+    ModeCode public mode = ModeLib.encodeSimpleSingle();
+    ModeCode public batchMode = ModeLib.encodeSimpleBatch();
+
+    ////////////////////////////// Setup //////////////////////////////
+    function setUp() public override {
+        super.setUp();
+        exactExecutionEnforcer = new ExactExecutionEnforcer();
+        vm.label(address(exactExecutionEnforcer), "Exact Execution Enforcer");
+        basicCF20 = new BasicERC20(address(users.alice.deleGator), "TestToken1", "TestToken1", 100 ether);
+    }
+
+    ////////////////////////////// Unit Tests //////////////////////////////
+
+    /// @notice Test that the enforcer passes when the execution matches exactly.
+    function test_exactExecutionMatches() public {
+        // Create an execution
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(10 ether))
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Use the exact execution as terms
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        vm.prank(address(delegationManager));
+        exactExecutionEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when the target doesn't match.
+    function test_exactExecutionFailsWhenTargetDiffers() public {
+        // Create an execution
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(10 ether))
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create terms with a different target
+        bytes memory terms_ = ExecutionLib.encodeSingle(address(users.bob.deleGator), execution_.value, execution_.callData);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionEnforcer:invalid-execution");
+        exactExecutionEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when the value doesn't match.
+    function test_exactExecutionFailsWhenValueDiffers() public {
+        // Create an execution
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(10 ether))
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create terms with a different value
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, 2 ether, execution_.callData);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionEnforcer:invalid-execution");
+        exactExecutionEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when the calldata doesn't match.
+    function test_exactExecutionFailsWhenCalldataDiffers() public {
+        // Create an execution
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(10 ether))
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create terms with different calldata
+        bytes memory differentCalldata_ =
+            abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(20 ether));
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, differentCalldata_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ExactExecutionEnforcer:invalid-execution");
+        exactExecutionEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    /// @notice Test that the enforcer reverts when batch mode is used.
+    function test_batchModeReverts() public {
+        // Create an execution
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(10 ether))
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+        exactExecutionEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256(""), address(0), address(0));
+    }
+
+    ////////////////////////////// Integration Tests //////////////////////////////
+
+    /// @notice Integration test: the enforcer allows a token transfer when execution matches exactly.
+    function test_integration_AllowsTokenTransferWhenExecutionMatches() public {
+        // Ensure Bob starts with a zero balance
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), uint256(0));
+
+        // Create an execution for a token transfer
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 0,
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Use the exact execution as terms
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactExecutionEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+
+        // Execute Bob's UserOp
+        invokeDelegation_UserOp(users.bob, delegations_, execution_);
+
+        // Verify Bob's balance increased
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), uint256(1 ether));
+    }
+
+    /// @notice Integration test: the enforcer blocks token transfer when execution doesn't match.
+    function test_integration_BlocksTokenTransferWhenExecutionDiffers() public {
+        // Ensure Bob starts with a zero balance
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), uint256(0));
+
+        // Create an execution with value=1 ether
+        Execution memory execution_ = Execution({
+            target: address(basicCF20),
+            value: 1 ether, // Non-zero value
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, address(users.bob.deleGator), uint256(1 ether))
+        });
+
+        // Create terms with value=0
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, 0, execution_.callData);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactExecutionEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+
+        // Execute Bob's UserOp
+        invokeDelegation_UserOp(users.bob, delegations_, execution_);
+
+        // Verify Bob's balance remains unchanged
+        assertEq(basicCF20.balanceOf(address(users.bob.deleGator)), uint256(0));
+    }
+
+    /// @notice Integration test: the enforcer allows ETH transfer when execution matches exactly.
+    function test_integration_AllowsETHTransferWhenExecutionMatches() public {
+        // Record Carol's initial ETH balance
+        uint256 initialBalance_ = address(users.carol.deleGator).balance;
+
+        // Create an execution for an ETH transfer
+        Execution memory execution_ = Execution({
+            target: address(users.carol.deleGator),
+            value: 1 ether,
+            callData: "" // Empty calldata for ETH transfer
+         });
+
+        // Use the exact execution as terms
+        bytes memory terms_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({ args: hex"", enforcer: address(exactExecutionEnforcer), terms: terms_ });
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+
+        // Execute Bob's UserOp
+        invokeDelegation_UserOp(users.bob, delegations_, execution_);
+
+        // Verify Carol's ETH balance increased
+        assertEq(address(users.carol.deleGator).balance, initialBalance_ + 1 ether);
+    }
+
+    ////////////////////////////// Internal Overrides //////////////////////////////
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(exactExecutionEnforcer));
+    }
+}


### PR DESCRIPTION
### **What?**

- A new Exact `Execution` enforcer that can be used to compare and validate an exact match between the terms Execution for single and batch executions.

### **Why?**

- This enforcer would be useful to enforce specific execution(s) in a single or batch call.

### **How?**

- The delegator encodes a single Execution type and the `ExactExecutionEnforcer` enforces the execution must match entirely. Or the delegator encodes an array of Execution types and the `ExactExecutionBatchEnforcer` enforces each execution must match entirely.
