### PR TITLE
Audit - Feb 2025 - 7.4.1 - Allow empty signatures

### DIFF
--- a/src/DelegationManager.sol
+++ b/src/DelegationManager.sol
@@ -29,7 +29,7 @@ contract DelegationManager is IDelegationManager, Ownable2Step, Pausable, EIP712
     string public constant NAME = "DelegationManager";
 
     /// @dev The full version of the contract
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.3.0";
 
     /// @dev The version used in the domainSeparator for EIP712
     string public constant DOMAIN_VERSION = "1";
@@ -160,11 +160,6 @@ contract DelegationManager is IDelegationManager, Ownable2Step, Pausable, EIP712
                 for (uint256 delegationsIndex_; delegationsIndex_ < delegations_.length; ++delegationsIndex_) {
                     Delegation memory delegation_ = delegations_[delegationsIndex_];
                     delegationHashes_[delegationsIndex_] = EncoderLib._getDelegationHash(delegation_);
-
-                    if (delegation_.signature.length == 0) {
-                        // Ensure that delegations without signatures revert
-                        revert EmptySignature();
-                    }
 
                     if (delegation_.delegator.code.length == 0) {
                         // Validate delegation if it's an EOA

--- a/test/DelegationManagerTest.t.sol
+++ b/test/DelegationManagerTest.t.sol
@@ -70,7 +70,7 @@ contract DelegationManagerTest is BaseTest {
     // Should allow reading contract version
     function test_allow_contractVersionReads() public {
         string memory contractVersion_ = delegationManager.VERSION();
-        assertEq("1.2.0", contractVersion_);
+        assertEq("1.3.0", contractVersion_);
     }
 
     // Should allow reading contract version


### PR DESCRIPTION
### **What?**

- Deleted restriction of empty signature for delegate signature. 

### **Why?**

- This allows the EOA or smart contract account to revert, some smart contract implementations stored signatures to avoid having to sign multiple times when an empty signature is passed.

### **How?**

- Deleted the Empty signature validation

## **Important**
- Please take a look that since there is a change in the delegation manager change something I decided to upgrade the version to align with the version of the other contracts
