### PR TITLE
Audit - Feb 2025 - 7.4.3 - Missing zero length check AllowedMethods & AllowedTargets

### DIFF
--- a/src/enforcers/AllowedMethodsEnforcer.sol
+++ b/src/enforcers/AllowedMethodsEnforcer.sol
@@ -62,7 +62,7 @@ contract AllowedMethodsEnforcer is CaveatEnforcer {
     function getTermsInfo(bytes calldata _terms) public pure returns (bytes4[] memory allowedMethods_) {
         uint256 j = 0;
         uint256 termsLength_ = _terms.length;
-        require(termsLength_ % 4 == 0, "AllowedMethodsEnforcer:invalid-terms-length");
+        require(termsLength_ % 4 == 0 && termsLength_ != 0, "AllowedMethodsEnforcer:invalid-terms-length");
         allowedMethods_ = new bytes4[](termsLength_ / 4);
         for (uint256 i = 0; i < termsLength_; i += 4) {
             allowedMethods_[j] = bytes4(_terms[i:i + 4]);

--- a/src/enforcers/AllowedTargetsEnforcer.sol
+++ b/src/enforcers/AllowedTargetsEnforcer.sol
@@ -57,7 +57,7 @@ contract AllowedTargetsEnforcer is CaveatEnforcer {
     function getTermsInfo(bytes calldata _terms) public pure returns (address[] memory allowedTargets_) {
         uint256 j = 0;
         uint256 termsLength_ = _terms.length;
-        require(termsLength_ % 20 == 0, "AllowedTargetsEnforcer:invalid-terms-length");
+        require(termsLength_ % 20 == 0 && termsLength_ != 0, "AllowedTargetsEnforcer:invalid-terms-length");
         allowedTargets_ = new address[](termsLength_ / 20);
         for (uint256 i = 0; i < termsLength_; i += 20) {
             allowedTargets_[j] = address(bytes20(_terms[i:i + 20]));

--- a/test/enforcers/AllowedMethodsEnforcer.t.sol
+++ b/test/enforcers/AllowedMethodsEnforcer.t.sol
@@ -76,6 +76,11 @@ contract AllowedMethodsEnforcerTest is CaveatEnforcerBaseTest {
 
     // should FAIL to get terms info when passing an invalid terms length
     function test_getTermsInfoFailsForInvalidLength() public {
+        // 0 bytes
+        vm.expectRevert("AllowedMethodsEnforcer:invalid-terms-length");
+        allowedMethodsEnforcer.getTermsInfo(hex"");
+
+        // Less than 4 bytes
         vm.expectRevert("AllowedMethodsEnforcer:invalid-terms-length");
         allowedMethodsEnforcer.getTermsInfo(bytes("1"));
     }

--- a/test/enforcers/AllowedTargetsEnforcer.t.sol
+++ b/test/enforcers/AllowedTargetsEnforcer.t.sol
@@ -79,6 +79,11 @@ contract AllowedTargetsEnforcerTest is CaveatEnforcerBaseTest {
 
     // should FAIL to get terms info when passing an invalid terms length
     function test_getTermsInfoFailsForInvalidLength() public {
+        // 0 bytes
+        vm.expectRevert("AllowedTargetsEnforcer:invalid-terms-length");
+        allowedTargetsEnforcer.getTermsInfo(hex"");
+
+        // Less than 4 bytes
         vm.expectRevert("AllowedTargetsEnforcer:invalid-terms-length");
         allowedTargetsEnforcer.getTermsInfo(bytes("1"));
     }


### PR DESCRIPTION
### **What?**

- Adding a validation for empty terms in the AllowedMethods & AllowedTargets enforcers

### **Why?**

- Empty terms in these enforcers are considered as mistakes
