### PR TITLE
Audit - Feb 2025 - 7.2.1 Execution and CallType Mode Modifier

### DIFF
--- a/documents/CaveatEnforcers.md
+++ b/documents/CaveatEnforcers.md
@@ -21,7 +21,7 @@ The order in which the caveat hooks are called can vary depending on the `Delega
 
 ### Execution Modes
 
-Enforcers can target a specific execution mode: **single** or **batch**. Because execution call data is encoded differently for each mode, you can use modifiers like `onlySingleExecutionMode` or `onlyBatchExecutionMode` to restrict an enforcer to the desired mode, using a different would revert.
+Enforcers can target specific call type modes: **single** or **batch**, and execution types: **default** or **revert**. Because execution call data is encoded differently for each mode, you can use modifiers like `onlySingleCallTypeMode`, `onlyBatchCallTypeMode` to restrict a call type, or `onlyDefaultExecutionMode`, `onlyTryExecutionMode` to restrict an execution type, it is possible to combine an execution mode modifier with a call type modifier.
 
 ---
 

--- a/lcov.info
+++ b/lcov.info
@@ -747,8 +747,8 @@ FNDA:74,CaveatEnforcer.onlySingleExecutionMode
 DA:27,74
 BRDA:27,0,0,-
 BRDA:27,0,1,74
-FN:34,CaveatEnforcer.onlyBatchExecutionMode
-FNDA:0,CaveatEnforcer.onlyBatchExecutionMode
+FN:34,CaveatEnforcer.onlyBatchCallTypeMode
+FNDA:0,CaveatEnforcer.onlyBatchCallTypeMode
 DA:35,0
 BRDA:35,1,0,-
 BRDA:35,1,1,-

--- a/src/enforcers/AllowedCalldataEnforcer.sol
+++ b/src/enforcers/AllowedCalldataEnforcer.sol
@@ -40,7 +40,7 @@ contract AllowedCalldataEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         // Ensure that the first two term values are valid and at least 1 byte for value_
         uint256 dataStart_;

--- a/src/enforcers/AllowedMethodsEnforcer.sol
+++ b/src/enforcers/AllowedMethodsEnforcer.sol
@@ -36,7 +36,7 @@ contract AllowedMethodsEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         (,, bytes calldata callData_) = _executionCallData.decodeSingle();
 

--- a/src/enforcers/AllowedTargetsEnforcer.sol
+++ b/src/enforcers/AllowedTargetsEnforcer.sol
@@ -35,7 +35,7 @@ contract AllowedTargetsEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         (address target_,,) = _executionCallData.decodeSingle();
 

--- a/src/enforcers/CaveatEnforcer.sol
+++ b/src/enforcers/CaveatEnforcer.sol
@@ -30,7 +30,9 @@ abstract contract CaveatEnforcer is ICaveatEnforcer {
      * @dev Require the function call to be in single call type
      */
     modifier onlySingleCallTypeMode(ModeCode _mode) {
-        require(ModeLib.getCallType(_mode) == CALLTYPE_SINGLE, "CaveatEnforcer:invalid-call-type");
+        {
+            require(ModeLib.getCallType(_mode) == CALLTYPE_SINGLE, "CaveatEnforcer:invalid-call-type");
+        }
         _;
     }
 
@@ -38,7 +40,9 @@ abstract contract CaveatEnforcer is ICaveatEnforcer {
      * @dev Require the function call to be in batch call type
      */
     modifier onlyBatchCallTypeMode(ModeCode _mode) {
-        require(ModeLib.getCallType(_mode) == CALLTYPE_BATCH, "CaveatEnforcer:invalid-call-type");
+        {
+            require(ModeLib.getCallType(_mode) == CALLTYPE_BATCH, "CaveatEnforcer:invalid-call-type");
+        }
         _;
     }
 
@@ -46,8 +50,10 @@ abstract contract CaveatEnforcer is ICaveatEnforcer {
      * @dev Require the function call to be in default execution mode
      */
     modifier onlyDefaultExecutionMode(ModeCode _mode) {
-        (, ExecType _execType,,) = _mode.decode();
-        require(_execType == EXECTYPE_DEFAULT, "CaveatEnforcer:invalid-execution-type");
+        {
+            (, ExecType _execType,,) = _mode.decode();
+            require(_execType == EXECTYPE_DEFAULT, "CaveatEnforcer:invalid-execution-type");
+        }
         _;
     }
 
@@ -55,8 +61,10 @@ abstract contract CaveatEnforcer is ICaveatEnforcer {
      * @dev Require the function call to be in try execution mode
      */
     modifier onlyTryExecutionMode(ModeCode _mode) {
-        (, ExecType _execType,,) = _mode.decode();
-        require(_execType == EXECTYPE_TRY, "CaveatEnforcer:invalid-execution-type");
+        {
+            (, ExecType _execType,,) = _mode.decode();
+            require(_execType == EXECTYPE_TRY, "CaveatEnforcer:invalid-execution-type");
+        }
         _;
     }
 }

--- a/src/enforcers/CaveatEnforcer.sol
+++ b/src/enforcers/CaveatEnforcer.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.23;
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 
 import { ICaveatEnforcer } from "../interfaces/ICaveatEnforcer.sol";
-import { ModeCode } from "../utils/Types.sol";
-import { CALLTYPE_SINGLE, CALLTYPE_BATCH } from "../utils/Constants.sol";
+import { ModeCode, ExecType } from "../utils/Types.sol";
+import { CALLTYPE_SINGLE, CALLTYPE_BATCH, EXECTYPE_DEFAULT, EXECTYPE_TRY } from "../utils/Constants.sol";
 
 /**
  * @title CaveatEnforcer
@@ -27,18 +27,36 @@ abstract contract CaveatEnforcer is ICaveatEnforcer {
     function afterAllHook(bytes calldata, bytes calldata, ModeCode, bytes calldata, bytes32, address, address) public virtual { }
 
     /**
-     * @dev Require the function call to be in single execution mode
+     * @dev Require the function call to be in single call type
      */
-    modifier onlySingleExecutionMode(ModeCode _mode) {
+    modifier onlySingleCallTypeMode(ModeCode _mode) {
         require(ModeLib.getCallType(_mode) == CALLTYPE_SINGLE, "CaveatEnforcer:invalid-call-type");
         _;
     }
 
     /**
-     * @dev Require the function call to be in batch execution mode
+     * @dev Require the function call to be in batch call type
      */
-    modifier onlyBatchExecutionMode(ModeCode _mode) {
+    modifier onlyBatchCallTypeMode(ModeCode _mode) {
         require(ModeLib.getCallType(_mode) == CALLTYPE_BATCH, "CaveatEnforcer:invalid-call-type");
+        _;
+    }
+
+    /**
+     * @dev Require the function call to be in default execution mode
+     */
+    modifier onlyDefaultExecutionMode(ModeCode _mode) {
+        (, ExecType _execType,,) = _mode.decode();
+        require(_execType == EXECTYPE_DEFAULT, "CaveatEnforcer:invalid-execution-type");
+        _;
+    }
+
+    /**
+     * @dev Require the function call to be in try execution mode
+     */
+    modifier onlyTryExecutionMode(ModeCode _mode) {
+        (, ExecType _execType,,) = _mode.decode();
+        require(_execType == EXECTYPE_TRY, "CaveatEnforcer:invalid-execution-type");
         _;
     }
 }

--- a/src/enforcers/ERC20PeriodTransferEnforcer.sol
+++ b/src/enforcers/ERC20PeriodTransferEnforcer.sol
@@ -126,7 +126,7 @@ contract ERC20PeriodTransferEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         _validateAndConsumeTransfer(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/ERC20StreamingEnforcer.sol
+++ b/src/enforcers/ERC20StreamingEnforcer.sol
@@ -59,40 +59,21 @@ contract ERC20StreamingEnforcer is CaveatEnforcer {
 
     /**
      * @notice Retrieves the current available allowance for a specific delegation.
-     * @param _delegationHash The hash of the delegation being queried.
      * @param _delegationManager The address of the delegation manager.
-     * @param _terms 148 packed bytes where:
-     * - 20 bytes: ERC20 token address.
-     * - 32 bytes: initial amount.
-     * - 32 bytes: max amount.
-     * - 32 bytes: amount per second.
-     * - 32 bytes: start time for the streaming allowance.
+     * @param _delegationHash The hash of the delegation being queried.
      * @return availableAmount_ The number of tokens that are currently spendable
      * under this streaming allowance (capped by `maxAmount`).
      */
     function getAvailableAmount(
-        bytes32 _delegationHash,
         address _delegationManager,
-        bytes calldata _terms
+        bytes32 _delegationHash
     )
         external
         view
         returns (uint256 availableAmount_)
     {
-        StreamingAllowance memory storedAllowance_ = streamingAllowances[_delegationManager][_delegationHash];
-        if (storedAllowance_.spent != 0) return _getAvailableAmount(storedAllowance_);
-
-        // Not yet initialized: simulate using provided terms.
-        (, uint256 initialAmount_, uint256 maxAmount_, uint256 amountPerSecond_, uint256 startTime_) = getTermsInfo(_terms);
-
-        StreamingAllowance memory allowance_ = StreamingAllowance({
-            initialAmount: initialAmount_,
-            maxAmount: maxAmount_,
-            amountPerSecond: amountPerSecond_,
-            startTime: startTime_,
-            spent: 0
-        });
-        return _getAvailableAmount(allowance_);
+        StreamingAllowance storage allowance_ = streamingAllowances[_delegationManager][_delegationHash];
+        availableAmount_ = _getAvailableAmount(allowance_);
     }
 
     /**
@@ -120,7 +101,7 @@ contract ERC20StreamingEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         _validateAndConsumeAllowance(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/ERC20TransferAmountEnforcer.sol
+++ b/src/enforcers/ERC20TransferAmountEnforcer.sol
@@ -46,7 +46,8 @@ contract ERC20TransferAmountEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         (uint256 limit_, uint256 spent_) = _validateAndIncrease(_terms, _executionCallData, _delegationHash);
         emit IncreasedSpentMap(msg.sender, _redeemer, _delegationHash, limit_, spent_);

--- a/src/enforcers/ERC721TransferEnforcer.sol
+++ b/src/enforcers/ERC721TransferEnforcer.sol
@@ -32,7 +32,7 @@ contract ERC721TransferEnforcer is CaveatEnforcer {
         public
         virtual
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         (address permittedContract_, uint256 permittedTokenId_) = getTermsInfo(_terms);
         (address target_,, bytes calldata callData_) = ExecutionLib.decodeSingle(_executionCallData);

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -36,7 +36,7 @@ contract ExactCalldataBatchEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlyBatchExecutionMode(_mode)
+        onlyBatchCallTypeMode(_mode)
     {
         Execution[] calldata executions_ = _executionCallData.decodeBatch();
         Execution[] memory termsExecutions_ = getTermsInfo(_terms);

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -10,7 +10,7 @@ import { ModeCode, Execution } from "../utils/Types.sol";
 /**
  * @title ExactCalldataBatchEnforcer
  * @notice Ensures that the provided batch execution calldata matches exactly the expected calldata for each execution.
- * @dev This caveat enforcer operates only in batch execution mode.
+ * @dev This enforcer operates only in batch execution call type and with default execution mode.
  */
 contract ExactCalldataBatchEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -37,6 +37,7 @@ contract ExactCalldataBatchEnforcer is CaveatEnforcer {
         pure
         override
         onlyBatchCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         Execution[] calldata executions_ = _executionCallData.decodeBatch();
         Execution[] memory termsExecutions_ = getTermsInfo(_terms);

--- a/src/enforcers/ExactCalldataEnforcer.sol
+++ b/src/enforcers/ExactCalldataEnforcer.sol
@@ -34,7 +34,7 @@ contract ExactCalldataEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         (,, bytes calldata callData_) = _executionCallData.decodeSingle();
 

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -36,7 +36,7 @@ contract ExactExecutionBatchEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlyBatchExecutionMode(_mode)
+        onlyBatchCallTypeMode(_mode)
     {
         Execution[] calldata executions_ = _executionCallData.decodeBatch();
         Execution[] memory termsExecutions_ = getTermsInfo(_terms);

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -10,7 +10,7 @@ import { ModeCode, Execution } from "../utils/Types.sol";
 /**
  * @title ExactExecutionBatchEnforcer
  * @notice Ensures that each execution in the batch matches exactly with the expected execution (target, value, and calldata).
- * @dev This caveat enforcer operates only in batch execution mode.
+ * @dev This enforcer operates only in batch execution call type and with default execution mode.
  */
 contract ExactExecutionBatchEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -37,6 +37,7 @@ contract ExactExecutionBatchEnforcer is CaveatEnforcer {
         pure
         override
         onlyBatchCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         Execution[] calldata executions_ = _executionCallData.decodeBatch();
         Execution[] memory termsExecutions_ = getTermsInfo(_terms);

--- a/src/enforcers/ExactExecutionEnforcer.sol
+++ b/src/enforcers/ExactExecutionEnforcer.sol
@@ -36,7 +36,7 @@ contract ExactExecutionEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         // Decode execution data
         (address execTarget_, uint256 execValue_, bytes calldata execCallData_) = _executionCallData.decodeSingle();

--- a/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
+++ b/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
@@ -118,7 +118,7 @@ contract NativeTokenPeriodTransferEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         _validateAndConsumeTransfer(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/NativeTokenStreamingEnforcer.sol
+++ b/src/enforcers/NativeTokenStreamingEnforcer.sol
@@ -56,38 +56,20 @@ contract NativeTokenStreamingEnforcer is CaveatEnforcer {
 
     /**
      * @notice Retrieves the current available allowance for a given delegation.
-     * @param _delegationHash The hash of the delegation.
      * @param _delegationManager The delegation manager address.
-     * @param _terms 128 packed bytes where:
-     * - 32 bytes: initial amount.
-     * - 32 bytes: max amount.
-     * - 32 bytes: amount per second.
-     * - 32 bytes: start time for the streaming allowance.
+     * @param _delegationHash The hash of the delegation.
      * @return availableAmount_ The native token amount available (capped by `maxAmount`).
      */
     function getAvailableAmount(
-        bytes32 _delegationHash,
         address _delegationManager,
-        bytes calldata _terms
+        bytes32 _delegationHash
     )
         external
         view
         returns (uint256 availableAmount_)
     {
-        StreamingAllowance memory storedAllowance_ = streamingAllowances[_delegationManager][_delegationHash];
-        if (storedAllowance_.spent != 0) return _getAvailableAmount(storedAllowance_);
-
-        // Not yet initialized: simulate using provided terms.
-        (uint256 initialAmount_, uint256 maxAmount_, uint256 amountPerSecond_, uint256 startTime_) = getTermsInfo(_terms);
-
-        StreamingAllowance memory allowance_ = StreamingAllowance({
-            initialAmount: initialAmount_,
-            maxAmount: maxAmount_,
-            amountPerSecond: amountPerSecond_,
-            startTime: startTime_,
-            spent: 0
-        });
-        return _getAvailableAmount(allowance_);
+        StreamingAllowance storage allowance_ = streamingAllowances[_delegationManager][_delegationHash];
+        availableAmount_ = _getAvailableAmount(allowance_);
     }
 
     /**
@@ -115,7 +97,7 @@ contract NativeTokenStreamingEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         _validateAndConsumeAllowance(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/NativeTokenTransferAmountEnforcer.sol
+++ b/src/enforcers/NativeTokenTransferAmountEnforcer.sol
@@ -44,7 +44,8 @@ contract NativeTokenTransferAmountEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         // Decode the total allowance from _terms
         uint256 allowance_ = getTermsInfo(_terms);

--- a/src/enforcers/OwnershipTransferEnforcer.sol
+++ b/src/enforcers/OwnershipTransferEnforcer.sol
@@ -41,7 +41,7 @@ contract OwnershipTransferEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         address newOwner = _validateAndEnforce(_terms, _executionCallData);
         emit OwnershipTransferEnforced(msg.sender, _redeemer, _delegationHash, newOwner);

--- a/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
+++ b/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
@@ -63,7 +63,7 @@ contract SpecificActionERC20TransferBatchEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlyBatchExecutionMode(_mode)
+        onlyBatchCallTypeMode(_mode)
     {
         // Check delegation hasn't been used
         if (usedDelegations[msg.sender][_delegationHash]) {

--- a/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
+++ b/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
@@ -14,6 +14,7 @@ import { ModeCode, Execution } from "../utils/Types.sol";
  * 1. First transaction must match specific target, method and calldata
  * 2. Second transaction must be an ERC20 transfer with specific parameters
  * @dev The delegation can only be executed once
+ * @dev This enforcer operates only in batch execution call type and with default execution mode.
  */
 contract SpecificActionERC20TransferBatchEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -64,6 +65,7 @@ contract SpecificActionERC20TransferBatchEnforcer is CaveatEnforcer {
         public
         override
         onlyBatchCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         // Check delegation hasn't been used
         if (usedDelegations[msg.sender][_delegationHash]) {

--- a/src/enforcers/ValueLteEnforcer.sol
+++ b/src/enforcers/ValueLteEnforcer.sol
@@ -33,7 +33,7 @@ contract ValueLteEnforcer is CaveatEnforcer {
         public
         pure
         override
-        onlySingleExecutionMode(_mode)
+        onlySingleCallTypeMode(_mode)
     {
         (, uint256 value_,) = _executionCallData.decodeSingle();
         uint256 termsValue_ = getTermsInfo(_terms);

--- a/test/DeleGatorTestSuite.t.sol
+++ b/test/DeleGatorTestSuite.t.sol
@@ -10,8 +10,8 @@ import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionHelper } from "@erc7579/core/ExecutionHelper.sol";
+import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 
 import { IERC7821 } from "../src/interfaces/IERC7821.sol";
 import { EIP7702DeleGatorCore } from "../src/EIP7702/EIP7702DeleGatorCore.sol";
@@ -44,7 +44,6 @@ import { MultiSigDeleGator } from "../src/MultiSigDeleGator.sol";
 import { EIP7702StatelessDeleGator } from "../src/EIP7702/EIP7702StatelessDeleGator.sol";
 
 abstract contract DeleGatorTestSuite is BaseTest {
-    using ModeLib for ModeCode;
     using MessageHashUtils for bytes32;
 
     ////////////////////////////// Setup //////////////////////
@@ -65,7 +64,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         bobDeleGatorCounter = new Counter(address(users.bob.deleGator));
 
         oneSingularMode = new ModeCode[](1);
-        oneSingularMode[0] = ModeLib.encodeSimpleSingle();
+        oneSingularMode[0] = singleDefaultMode;
     }
 
     ////////////////////////////// State //////////////////////////////
@@ -1263,7 +1262,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         // Execute Executions
         bytes memory userOpCallData_ = abi.encodeWithSignature(
             EXECUTE_SIGNATURE,
-            ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, ModePayload.wrap(0x00)),
+            singleDefaultMode,
             ExecutionLib.encodeSingle(address(aliceDeleGatorCounter), 0, abi.encodeWithSelector(Counter.increment.selector))
         );
         PackedUserOperation memory userOp_ = createUserOp(address(users.alice.deleGator), userOpCallData_);
@@ -1298,11 +1297,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         });
 
         // Execute Executions
-        bytes memory userOpCallData_ = abi.encodeWithSignature(
-            EXECUTE_SIGNATURE,
-            ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_DEFAULT, MODE_DEFAULT, ModePayload.wrap(0x00)),
-            abi.encode(executionCallDatas_)
-        );
+        bytes memory userOpCallData_ = abi.encodeWithSignature(EXECUTE_SIGNATURE, batchDefaultMode, abi.encode(executionCallDatas_));
         PackedUserOperation memory userOp_ = createUserOp(address(users.alice.deleGator), userOpCallData_);
         bytes32 userOpHash_ = getPackedUserOperationTypedDataHash(userOp_);
         userOp_.signature = signHash(users.alice, userOpHash_);
@@ -1323,7 +1318,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         // Execute Executions
         bytes memory userOpCallData_ = abi.encodeWithSignature(
             EXECUTE_SIGNATURE,
-            ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00)),
+            singleTryMode,
             ExecutionLib.encodeSingle(address(aliceDeleGatorCounter), 0, abi.encodeWithSelector(Counter.increment.selector))
         );
         PackedUserOperation memory userOp_ = createUserOp(address(users.alice.deleGator), userOpCallData_);
@@ -1357,11 +1352,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         });
 
         // Execute Executions
-        bytes memory userOpCallData_ = abi.encodeWithSignature(
-            EXECUTE_SIGNATURE,
-            ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00)),
-            abi.encode(executionCallDatas_)
-        );
+        bytes memory userOpCallData_ = abi.encodeWithSignature(EXECUTE_SIGNATURE, batchTryMode, abi.encode(executionCallDatas_));
         PackedUserOperation memory userOp_ = createUserOp(address(users.alice.deleGator), userOpCallData_);
         bytes32 userOpHash_ = getPackedUserOperationTypedDataHash(userOp_);
         userOp_.signature = signHash(users.alice, userOpHash_);
@@ -1561,7 +1552,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         // Execute Execution
         vm.prank(address(delegationManager));
         users.alice.deleGator.executeFromExecutor(
-            ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, ModePayload.wrap(0x00)),
+            singleDefaultMode,
             ExecutionLib.encodeSingle(address(aliceDeleGatorCounter), 0, abi.encodeWithSelector(Counter.increment.selector))
         );
 
@@ -1590,10 +1581,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
             callData: abi.encodeWithSelector(Counter.increment.selector)
         });
         vm.prank(address(delegationManager));
-        users.alice.deleGator.executeFromExecutor(
-            ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_DEFAULT, MODE_DEFAULT, ModePayload.wrap(0x00)),
-            ExecutionLib.encodeBatch(executions_)
-        );
+        users.alice.deleGator.executeFromExecutor(batchDefaultMode, ExecutionLib.encodeBatch(executions_));
 
         // Get final count
         uint256 finalValue_ = aliceDeleGatorCounter.count();
@@ -1610,7 +1598,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
         // Execute Execution
         vm.prank(address(delegationManager));
         users.alice.deleGator.executeFromExecutor(
-            ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00)),
+            singleTryMode,
             ExecutionLib.encodeSingle(address(aliceDeleGatorCounter), 0, abi.encodeWithSelector(Counter.increment.selector))
         );
 
@@ -1639,10 +1627,7 @@ abstract contract DeleGatorTestSuite is BaseTest {
             callData: abi.encodeWithSelector(Counter.increment.selector)
         });
         vm.prank(address(delegationManager));
-        users.alice.deleGator.executeFromExecutor(
-            ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00)),
-            ExecutionLib.encodeBatch(executions_)
-        );
+        users.alice.deleGator.executeFromExecutor(batchTryMode, ExecutionLib.encodeBatch(executions_));
 
         // Get final count
         uint256 finalValue_ = aliceDeleGatorCounter.count();
@@ -1740,12 +1725,11 @@ abstract contract DeleGatorTestSuite is BaseTest {
         // Invalid execution_, sending ETH to a contract that can't receive it.
         Execution memory execution_ = Execution({ target: address(aliceDeleGatorCounter), value: 1, callData: hex"" });
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
-        ModeCode mode_ = ModeLib.encodeSimpleSingle();
 
         vm.prank(address(delegationManager));
         // Expect it to emit a bubbled up reverted event
         vm.expectRevert();
-        users.alice.deleGator.executeFromExecutor(mode_, executionCallData_);
+        users.alice.deleGator.executeFromExecutor(singleDefaultMode, executionCallData_);
     }
 
     // should NOT allow Carol to redeem a delegation to Bob through a UserOp (offchain)
@@ -2187,10 +2171,9 @@ abstract contract DeleGatorTestSuite is BaseTest {
             callData: abi.encodeWithSelector(Counter.increment.selector)
         });
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
-        ModeCode mode_ = ModeLib.encodeSimpleSingle();
 
         vm.expectRevert(abi.encodeWithSelector(DeleGatorCore.NotDelegationManager.selector));
-        users.alice.deleGator.executeFromExecutor(mode_, executionCallData_);
+        users.alice.deleGator.executeFromExecutor(singleDefaultMode, executionCallData_);
     }
 
     // Should revert if execute is called from an address other than the EntryPoint

--- a/test/DelegationManagerTest.t.sol
+++ b/test/DelegationManagerTest.t.sol
@@ -6,7 +6,6 @@ import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { ShortStrings, ShortString } from "@openzeppelin/contracts/utils/ShortStrings.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { Counter } from "./utils/Counter.t.sol";
@@ -22,7 +21,6 @@ import { MockCaveatEnforcer } from "./utils/MockCaveatEnforcer.sol";
 import { MockFailureCaveatEnforcer } from "./utils/MockFailureCaveatEnforcer.sol";
 
 contract DelegationManagerTest is BaseTest {
-    using ModeLib for ModeCode;
     using ShortStrings for *;
 
     ////////////////////////////// Setup //////////////////////////////
@@ -41,11 +39,11 @@ contract DelegationManagerTest is BaseTest {
         super.setUp();
 
         _oneSingularMode = new ModeCode[](1);
-        _oneSingularMode[0] = ModeLib.encodeSimpleSingle();
+        _oneSingularMode[0] = singleDefaultMode;
 
         _twoSingularModes = new ModeCode[](2);
-        _twoSingularModes[0] = ModeLib.encodeSimpleSingle();
-        _twoSingularModes[1] = ModeLib.encodeSimpleSingle();
+        _twoSingularModes[0] = singleDefaultMode;
+        _twoSingularModes[1] = singleDefaultMode;
 
         counter = new Counter(users.alice.addr);
     }

--- a/test/EIP7702StatelessDeleGatorTest.t.sol
+++ b/test/EIP7702StatelessDeleGatorTest.t.sol
@@ -25,10 +25,8 @@ import { ERC1271Lib } from "../src/libraries/ERC1271Lib.sol";
 import { EIP7702DeleGatorCore } from "../src/EIP7702/EIP7702DeleGatorCore.sol";
 import {
     CALLTYPE_SINGLE,
-    CALLTYPE_BATCH,
     CALLTYPE_DELEGATECALL,
     EXECTYPE_DEFAULT,
-    EXECTYPE_TRY,
     MODE_DEFAULT,
     ModeLib,
     ExecType,
@@ -218,9 +216,6 @@ contract EIP7702StatelessDeleGatorTest is BaseTest {
 
     // Test for function: execute(ModeCode _mode, bytes calldata _executionCalldata)
     function test_execute_ModeCode_accessControl() public {
-        // We'll create a ModeCode that represents a single revert on failure
-        ModeCode singleRevertMode_ = ModeCode.wrap(0);
-
         // The callData for a single call: (target, value, callData)
         // We'll encode it via ExecutionLib or by standard abi.encodePacked:
         bytes memory execCalldata_ =
@@ -230,19 +225,19 @@ contract EIP7702StatelessDeleGatorTest is BaseTest {
         address randomUser_ = address(0x12345);
         vm.prank(randomUser_);
         vm.expectRevert(EIP7702DeleGatorCore.NotEntryPointOrSelf.selector);
-        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+        aliceDeleGator.execute(singleDefaultMode, execCalldata_);
 
         // 2. Call from the entry point -> Should succeed
         uint256 initialCount_ = aliceDeleGatorCounter.count();
         vm.prank(address(entryPoint));
-        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+        aliceDeleGator.execute(singleDefaultMode, execCalldata_);
         uint256 finalCount_ = aliceDeleGatorCounter.count();
         assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented from entryPoint call");
 
         // 3. Call from the contract itself -> Should succeed
         initialCount_ = aliceDeleGatorCounter.count();
         vm.prank(address(aliceDeleGator));
-        aliceDeleGator.execute(singleRevertMode_, execCalldata_);
+        aliceDeleGator.execute(singleDefaultMode, execCalldata_);
         finalCount_ = aliceDeleGatorCounter.count();
         assertEq(finalCount_, initialCount_ + 1, "Counter should have incremented from self-call");
     }
@@ -251,15 +246,10 @@ contract EIP7702StatelessDeleGatorTest is BaseTest {
     function test_supportsExecutionMode() public {
         ModePayload modePayloadDefault_ = ModePayload.wrap(bytes22(0x00));
 
-        ModeCode singleRevertMode_ = ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, modePayloadDefault_);
-        ModeCode singleTryMode_ = ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, MODE_DEFAULT, modePayloadDefault_);
-        ModeCode batchRevertMode_ = ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, modePayloadDefault_);
-        ModeCode batchTryMode_ = ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, modePayloadDefault_);
-
-        assertTrue(aliceDeleGator.supportsExecutionMode(singleRevertMode_), "should support single revert");
-        assertTrue(aliceDeleGator.supportsExecutionMode(singleTryMode_), "should support single try");
-        assertTrue(aliceDeleGator.supportsExecutionMode(batchRevertMode_), "should support batch revert");
-        assertTrue(aliceDeleGator.supportsExecutionMode(batchTryMode_), "should support batch try");
+        assertTrue(aliceDeleGator.supportsExecutionMode(singleDefaultMode), "should support single revert");
+        assertTrue(aliceDeleGator.supportsExecutionMode(singleTryMode), "should support single try");
+        assertTrue(aliceDeleGator.supportsExecutionMode(batchDefaultMode), "should support batch revert");
+        assertTrue(aliceDeleGator.supportsExecutionMode(batchTryMode), "should support batch try");
 
         // Test a random/unsupported mode
         ModeCode unsupportedMode_ = ModeCode.wrap(bytes32(uint256(12345)));

--- a/test/HybridDeleGatorTest.t.sol
+++ b/test/HybridDeleGatorTest.t.sol
@@ -6,7 +6,6 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { FCL_ecdsa_utils } from "@FCL/FCL_ecdsa_utils.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";
-import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { SigningUtilsLib } from "./utils/SigningUtilsLib.t.sol";
 import { StorageUtilsLib } from "./utils/StorageUtilsLib.t.sol";

--- a/test/InviteTest.t.sol
+++ b/test/InviteTest.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.23;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { BaseTest } from "./utils/BaseTest.t.sol";
@@ -20,7 +19,6 @@ import { UserOperationLib } from "./utils/UserOperationLib.t.sol";
 
 contract InviteTest is BaseTest {
     using MessageHashUtils for bytes32;
-    using ModeLib for ModeCode;
 
     constructor() {
         IMPLEMENTATION = Implementation.Hybrid;
@@ -183,7 +181,7 @@ contract InviteTest is BaseTest {
         executionCallDatas_[0] = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         ModeCode[] memory modes_ = new ModeCode[](1);
-        modes_[0] = ModeLib.encodeSimpleSingle();
+        modes_[0] = singleDefaultMode;
 
         bytes memory userOpCallData_ =
             abi.encodeWithSelector(DeleGatorCore.redeemDelegations.selector, permissionContexts_, modes_, executionCallDatas_);

--- a/test/enforcers/AllowedCalldataEnforcer.t.sol
+++ b/test/enforcers/AllowedCalldataEnforcer.t.sol
@@ -4,11 +4,10 @@ pragma solidity 0.8.23;
 import "forge-std/Test.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { Counter } from "../utils/Counter.t.sol";
-import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { AllowedCalldataEnforcer } from "../../src/enforcers/AllowedCalldataEnforcer.sol";
 import { IDelegationManager } from "../../src/interfaces/IDelegationManager.sol";
@@ -23,13 +22,10 @@ contract DummyContract {
 }
 
 contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     AllowedCalldataEnforcer public allowedCalldataEnforcer;
     BasicERC20 public basicCF20;
     BasicCF721 public basicCF721;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -59,7 +55,9 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory inputTerms_ = abi.encodePacked(paramStart_, paramValue_);
 
         vm.prank(address(delegationManager));
-        allowedCalldataEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should allow a method to be called when a single function parameter that is a dynamic array
@@ -81,9 +79,15 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory parameterTerms_ = abi.encodePacked(uint256(68), BytesLib.slice(execution_.callData, uint256(68), uint256(64)));
 
         vm.prank(address(delegationManager));
-        allowedCalldataEnforcer.beforeHook(offsetTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
-        allowedCalldataEnforcer.beforeHook(lengthTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
-        allowedCalldataEnforcer.beforeHook(parameterTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            offsetTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+        allowedCalldataEnforcer.beforeHook(
+            lengthTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+        allowedCalldataEnforcer.beforeHook(
+            parameterTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should allow a single method to be called when a single function parameter that is dynamic is equal
@@ -103,9 +107,15 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory parameterTerms_ = abi.encodePacked(uint256(68), BytesLib.slice(execution_.callData, uint256(68), uint256(32)));
 
         vm.prank(address(delegationManager));
-        allowedCalldataEnforcer.beforeHook(offsetTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
-        allowedCalldataEnforcer.beforeHook(lengthTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
-        allowedCalldataEnforcer.beforeHook(parameterTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            offsetTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+        allowedCalldataEnforcer.beforeHook(
+            lengthTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+        allowedCalldataEnforcer.beforeHook(
+            parameterTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should allow Artist to create NFT specific delegations with metadata caveat
@@ -126,7 +136,9 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         // NOTE: Using encodedData_ not  encodedMetadataString_ to ensure the value for the offset is correct
         bytes memory allowedCalldata_ = abi.encodePacked(start_, BytesLib.slice(encodedData_, uint256(start_), uint256(length_)));
-        allowedCalldataEnforcer.beforeHook(allowedCalldata_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            allowedCalldata_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     ////////////////////// Invalid cases //////////////////////
@@ -148,7 +160,9 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         vm.expectRevert("AllowedCalldataEnforcer:invalid-calldata");
-        allowedCalldataEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should NOT allow to pass an invalid calldata length (invalid terms)
@@ -168,7 +182,9 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         vm.expectRevert("AllowedCalldataEnforcer:invalid-calldata-length");
-        allowedCalldataEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should NOT allow a method to be called when a terms size is invalid
@@ -187,7 +203,18 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         vm.expectRevert("AllowedCalldataEnforcer:invalid-terms-size");
-        allowedCalldataEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        allowedCalldataEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+    }
+
+    // should fail with invalid call type mode (batch instead of single mode)
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        allowedCalldataEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     ////////////////////// Integration //////////////////////

--- a/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
+++ b/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
@@ -1,20 +1,15 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 pragma solidity 0.8.23;
 
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
-
 import "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ArgsEqualityCheckEnforcer } from "../../src/enforcers/ArgsEqualityCheckEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract ArgsEqualityCheckEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////// State //////////////////////
 
     ArgsEqualityCheckEnforcer public argsEqualityCheckEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -31,7 +26,7 @@ contract ArgsEqualityCheckEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = bytes("This is an example");
         bytes memory args_ = bytes("This is an example");
         argsEqualityCheckEnforcer.beforeHook(
-            terms_, args_, mode, abi.encode(new Execution[](1)[0]), bytes32(0), address(0), address(0)
+            terms_, args_, singleDefaultMode, abi.encode(new Execution[](1)[0]), bytes32(0), address(0), address(0)
         );
     }
 
@@ -47,7 +42,7 @@ contract ArgsEqualityCheckEnforcerTest is CaveatEnforcerBaseTest {
         vm.expectEmit(true, true, true, true, address(argsEqualityCheckEnforcer));
         emit ArgsEqualityCheckEnforcer.DifferentArgsAndTerms(address(delegationManager), redeemer_, bytes32(0), terms_, args_);
         argsEqualityCheckEnforcer.beforeHook(
-            terms_, args_, mode, abi.encode(new Execution[](1)[0]), bytes32(0), address(0), redeemer_
+            terms_, args_, singleDefaultMode, abi.encode(new Execution[](1)[0]), bytes32(0), address(0), redeemer_
         );
     }
 

--- a/test/enforcers/BlockNumberEnforcer.t.sol
+++ b/test/enforcers/BlockNumberEnforcer.t.sol
@@ -3,10 +3,9 @@ pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
 import { Counter } from "../utils/Counter.t.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { BlockNumberEnforcer } from "../../src/enforcers/BlockNumberEnforcer.sol";
@@ -18,7 +17,6 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
     ////////////////////// State //////////////////////
 
     BlockNumberEnforcer public blockNumberEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -45,7 +43,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         uint128 blockBeforeThreshold_ = 0; // Not using before threshold
         bytes memory inputTerms_ = abi.encodePacked(blockAfterThreshold_, blockBeforeThreshold_);
         vm.prank(address(delegationManager));
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     //should SUCCEED to INVOKE method BEFORE blockNumber reached
@@ -62,7 +62,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         uint128 blockBeforeThreshold_ = uint128(block.number + 10000);
         bytes memory inputTerms_ = abi.encodePacked(blockAfterThreshold_, blockBeforeThreshold_);
         vm.prank(address(delegationManager));
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should SUCCEED to INVOKE method inside blockNumber RANGE
@@ -80,7 +82,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         vm.roll(1000); // making block number between 1 and 10001
         bytes memory inputTerms_ = abi.encodePacked(blockAfterThreshold_, blockBeforeThreshold_);
         vm.prank(address(delegationManager));
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     ////////////////////// Invalid cases //////////////////////
@@ -107,7 +111,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("BlockNumberEnforcer:early-delegation");
 
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should FAIL to INVOKE method AFTER blockNumber reached
@@ -127,7 +133,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("BlockNumberEnforcer:expired-delegation");
 
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should FAIL to INVOKE method BEFORE blocknumber RANGE
@@ -146,7 +154,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("BlockNumberEnforcer:early-delegation");
 
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     // should FAIL to INVOKE method AFTER blocknumber RANGE"
@@ -166,7 +176,9 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("BlockNumberEnforcer:expired-delegation");
 
-        blockNumberEnforcer.beforeHook(inputTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        blockNumberEnforcer.beforeHook(
+            inputTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     ////////////////////// Integration //////////////////////

--- a/test/enforcers/DeployedEnforcer.t.sol
+++ b/test/enforcers/DeployedEnforcer.t.sol
@@ -2,10 +2,9 @@
 pragma solidity 0.8.23;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { DeployedEnforcer } from "../../src/enforcers/DeployedEnforcer.sol";
 import { IDelegationManager } from "../../src/interfaces/IDelegationManager.sol";
@@ -13,13 +12,10 @@ import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
 
     DeployedEnforcer public deployedEnforcer;
     bytes32 public salt;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////////////// Events //////////////////////////////
 
@@ -72,7 +68,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(predictedAddr_, salt, abi.encodePacked(type(Counter).creationCode)),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -104,7 +100,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(predictedAddr_, salt, bytecode_),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -120,7 +116,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(predictedAddr_, salt, bytecode_),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -146,7 +142,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(users.alice.addr, salt, abi.encodePacked(type(Counter).creationCode)),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -168,12 +164,12 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
 
         // 0 bytes
         vm.expectRevert("DeployedEnforcer:invalid-terms-length");
-        deployedEnforcer.beforeHook(hex"", hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        deployedEnforcer.beforeHook(hex"", hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0));
 
         // 20 bytes
         vm.expectRevert("DeployedEnforcer:invalid-terms-length");
         deployedEnforcer.beforeHook(
-            abi.encodePacked(users.alice.addr), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(users.alice.addr), hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
         );
 
         // 52 bytes
@@ -181,7 +177,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(users.alice.addr, bytes32(hex"")),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -211,7 +207,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(predictedAddr_, salt, bytecode_),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),
@@ -245,7 +241,7 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         deployedEnforcer.beforeHook(
             abi.encodePacked(predictedAddr_, salt, abi.encodePacked(type(Counter).creationCode)),
             hex"",
-            mode,
+            singleDefaultMode,
             executionCallData_,
             keccak256(""),
             address(0),

--- a/test/enforcers/DeployedEnforcer.t.sol
+++ b/test/enforcers/DeployedEnforcer.t.sol
@@ -260,7 +260,6 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         // NOTE: Execution isn't very relevant for this test.
         Execution memory execution_ =
             Execution({ target: predictedAddr_, value: 0, callData: abi.encodeWithSelector(Counter.setCount.selector, 1) });
-        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Check that the contract hasn't been deployed yet
         bytes memory initialCode_ = predictedAddr_.code;

--- a/test/enforcers/ERC1155BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC1155BalanceGteEnforcer.t.sol
@@ -2,10 +2,8 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { BasicERC1155 } from "../utils/BasicERC1155.t.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
-
 import "../../src/utils/Types.sol";
+import { BasicERC1155 } from "../utils/BasicERC1155.t.sol";
 import { Execution } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ERC1155BalanceGteEnforcer } from "../../src/enforcers/ERC1155BalanceGteEnforcer.sol";
@@ -20,7 +18,6 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
     address dm;
     Execution mintExecution;
     bytes mintExecutionCallData;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     uint256 public tokenId = 1;
 
@@ -64,19 +61,19 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 100
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.prank(delegator);
         token.mint(delegator, tokenId, 100, "");
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // Increase by 1000
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.prank(delegator);
         token.mint(delegator, tokenId, 1000, "");
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     ////////////////////// Errors //////////////////////
@@ -88,12 +85,12 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 10, expect revert
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.prank(delegator);
         token.mint(delegator, tokenId, 10, "");
         vm.prank(dm);
         vm.expectRevert(bytes("ERC1155BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Reverts if a balance descreased in between the hooks
@@ -106,7 +103,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), uint256(tokenId), uint256(100));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // Decrease balance by transferring tokens away
         vm.prank(delegator);
@@ -114,7 +111,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert(bytes("ERC1155BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Allows to check the balance of different recipients
@@ -129,11 +126,11 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
             // Increase by 100 for each recipient
             vm.prank(dm);
-            enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(i), address(0), delegate);
+            enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(i), address(0), delegate);
             vm.prank(delegator);
             token.mint(currentRecipient_, tokenId, 100, "");
             vm.prank(dm);
-            enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(i), address(0), delegate);
+            enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(i), address(0), delegate);
         }
     }
 
@@ -147,7 +144,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), uint256(tokenId), uint256(100));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // Increase balance by 100
         vm.prank(delegator);
@@ -155,7 +152,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert(bytes("ERC1155BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Same delegation hash multiple recipients
@@ -167,10 +164,10 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms2_ = abi.encodePacked(address(token), address(recipient2_), uint256(tokenId), uint256(100));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms1_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         vm.prank(dm);
-        enforcer.beforeHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // Increase balance by 100 only in recipient1
         vm.prank(delegator);
@@ -178,12 +175,12 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // This one works well recipient1 increased
         vm.prank(dm);
-        enforcer.afterHook(terms1_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // This one fails recipient1 didn't increase
         vm.prank(dm);
         vm.expectRevert(bytes("ERC1155BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // Increase balance by 100 only in recipient2 to fix it
         vm.prank(delegator);
@@ -191,7 +188,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Recipient2 works well
         vm.prank(dm);
-        enforcer.afterHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
     }
 
     // Reverts if the enforcer is locked
@@ -202,12 +199,12 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Lock the enforcer
         vm.startPrank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         bytes32 hashKey_ =
             enforcer.getHashKey(address(delegationManager), address(token), address(delegator), tokenId, delegationHash_);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.expectRevert(bytes("ERC1155BalanceGteEnforcer:enforcer-is-locked"));
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         vm.stopPrank();
 
         vm.prank(delegator);
@@ -215,10 +212,10 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.startPrank(dm);
         // Unlock the enforcer
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         assertFalse(enforcer.isLocked(hashKey_));
         // Can be used again, and locks it again
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.stopPrank();
     }
@@ -245,7 +242,7 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         // Invalid token address
         terms_ = abi.encodePacked(address(0), address(delegator), uint256(tokenId), uint256(100));
         vm.expectRevert();
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Validates that an invalid amount causes a revert
@@ -254,9 +251,9 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), uint256(tokenId), type(uint256).max);
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.expectRevert();
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     //////////////////////  Integration  //////////////////////

--- a/test/enforcers/ERC20BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC20BalanceGteEnforcer.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicERC20 } from "../utils/BasicERC20.t.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 
 import "../../src/utils/Types.sol";
 import { Execution } from "../../src/utils/Types.sol";
@@ -21,7 +20,6 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
     address dm;
     Execution mintExecution;
     bytes mintExecutionCallData;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -61,19 +59,19 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 100
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.prank(delegator);
         token.mint(recipient, 100);
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
 
         // Increase by 1000
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.prank(delegator);
         token.mint(recipient, 1000);
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Validates that the delegation can be reused with different recipients
@@ -108,12 +106,12 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 10, expect revert
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.prank(delegator);
         token.mint(recipient, 10);
         vm.prank(dm);
         vm.expectRevert(bytes("ERC20BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Reverts if a enforcer is locked
@@ -125,20 +123,20 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         // Increase by 100
         vm.startPrank(dm);
         // Locks the enforcer
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, delegator, delegate);
         bytes32 hashKey_ = enforcer.getHashKey(address(delegationManager), address(token), delegationHash_);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.expectRevert(bytes("ERC20BalanceGteEnforcer:enforcer-is-locked"));
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, delegator, delegate);
         vm.startPrank(delegator);
         token.mint(recipient, 1000);
         vm.startPrank(dm);
 
         // Unlocks the enforcer
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, delegator, delegate);
         assertFalse(enforcer.isLocked(hashKey_));
         // Can be used again, and locks it again
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, delegator, delegate);
         assertTrue(enforcer.isLocked(hashKey_));
     }
 
@@ -178,7 +176,7 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         // Invalid token
         terms_ = abi.encodePacked(address(recipient), address(0), uint256(100));
         vm.expectRevert();
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Validates that an invalid ID reverts
@@ -188,9 +186,9 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.expectRevert();
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     //////////////////////  Integration  //////////////////////

--- a/test/enforcers/ERC20BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC20BalanceGteEnforcer.t.sol
@@ -82,19 +82,19 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 100, check for recipient
         vm.prank(dm);
-        enforcer.beforeHook(terms1_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.prank(delegator);
         token.mint(recipient, 100);
         vm.prank(dm);
-        enforcer.afterHook(terms1_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
 
         // Increase by 100, check for delegator as recipient
         vm.prank(dm);
-        enforcer.beforeHook(terms2_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
         vm.prank(delegator);
         token.mint(delegator, 100);
         vm.prank(dm);
-        enforcer.afterHook(terms2_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // ////////////////////// Errors //////////////////////
@@ -146,12 +146,12 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // BeforeHook should cache the recipient's balance
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
 
         // No tokens are minted to the recipient, so balance shouldn't increase
         vm.prank(dm);
         vm.expectRevert(bytes("ERC20BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Validates the terms are well formed

--- a/test/enforcers/ERC20StreamingEnforcer.t.sol
+++ b/test/enforcers/ERC20StreamingEnforcer.t.sol
@@ -2,10 +2,9 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { ModeCode, Caveat, Delegation, Execution } from "../../src/utils/Types.sol";
+import { Caveat, Delegation, Execution } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ERC20StreamingEnforcer } from "../../src/enforcers/ERC20StreamingEnforcer.sol";
 import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
@@ -13,12 +12,9 @@ import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
 
 contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     ERC20StreamingEnforcer public erc20StreamingEnforcer;
     BasicERC20 public basicERC20;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
     address public alice;
     address public bob;
     address public carol;
@@ -52,7 +48,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-terms-length"));
-        erc20StreamingEnforcer.beforeHook(badTerms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(badTerms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -72,7 +68,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-max-amount"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -87,7 +83,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-zero-start-time"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -104,7 +100,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:allowance-exceeded"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /// @notice Test that it reverts with `ERC20StreamingEnforcer:invalid-execution-length` if the callData_ is not 68 bytes.
@@ -116,7 +112,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, badCallData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-execution-length"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -132,7 +128,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, badCallData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-method"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /// @notice Test that it reverts with `ERC20StreamingEnforcer:invalid-contract` if the token address doesn't match the target.
@@ -146,7 +142,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeSingleExecution(address(otherToken_), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-contract"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     //////////////////// Valid cases //////////////////////
@@ -218,7 +214,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         erc20StreamingEnforcer.beforeHook(
             terms_,
             bytes(""), // no additional data
-            mode, // single execution mode
+            singleDefaultMode, // single execution singleDefaultMode
             execData_,
             bytes32(0), // example delegation hash
             address(0), // extra param (unused here)
@@ -250,10 +246,10 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
 
         // Calls beforeHook expecting no tokens to be spendable => must revert
         vm.expectRevert("ERC20StreamingEnforcer:allowance-exceeded");
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // Checking getAvailableAmount directly also returns 0
-        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Expected 0 tokens available before start time");
     }
 
@@ -271,7 +267,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
             block.timestamp
         );
 
-        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Should have 0 tokens available");
 
         // After 3 seconds => 3 unlocked (since initial=0)
@@ -280,15 +276,15 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         // Transfer 2 => ok
         bytes memory callData_ = _encodeERC20Transfer(bob, 2 ether);
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // 3 were unlocked, spent=2 => 1 left
-        available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 1 ether, "Should have 1 ether left after spending 2 of 3");
 
         // Another 10 seconds => total unlocked=3+10=13, but clamp at max=5 => total=5 => spent=2 => 3 left
         vm.warp(block.timestamp + 10);
-        available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 3 ether, "Should clamp at max=5, spent=2 => 3 remain");
     }
 
@@ -304,23 +300,23 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         // Transfer 5 immediately => 5 left (spent=5)
         bytes memory callData_ = _encodeERC20Transfer(bob, 5 ether);
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // spent=5, unlocked=10 => 5 remain
-        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 5 ether, "Should have 5 left from the initial chunk after spending 5");
 
         // warp 5 seconds => totalUnlocked=10 + (2*5)=20 => at or beyond max=20 => clamp=20 => spent=5 => 15 left
         vm.warp(block.timestamp + 5);
-        available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 15 ether, "Should have 15 left after 5 seconds of linear accrual, clamped at 20");
 
         // Transfer 15 => total spent=20 => 0 remain
         callData_ = _encodeERC20Transfer(bob, 15 ether);
         execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
-        available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Should have 0 left after spending 20 total");
     }
 
@@ -339,7 +335,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory callData_ = _encodeERC20Transfer(bob, 5 ether);
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // Now spent == maxAmount (5). No more tokens remain.
         // Another attempt to transfer any positive amount should revert
@@ -347,7 +343,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
         vm.expectRevert(bytes("ERC20StreamingEnforcer:allowance-exceeded"));
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -356,44 +352,33 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
     function test_availableAtExactStartTime() public {
         uint256 startTime_ = block.timestamp + 10;
         // initial=8, max=50, rate=2 => at startTime
-        bytes memory terms_ = _encodeTerms(address(basicERC20), 8 ether, 50 ether, 2 ether, startTime_);
+        bytes memory terms = _encodeTerms(address(basicERC20), 8 ether, 50 ether, 2 ether, startTime_);
         vm.warp(startTime_);
 
         // Transfer the full 8 => should succeed
         bytes memory callData_ = _encodeERC20Transfer(bob, 8 ether);
         bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 0, callData_);
 
-        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        erc20StreamingEnforcer.beforeHook(terms, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
-        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "After transferring the initial amount 8 ether, 0 should remain at start date");
 
         // 5 seconds after start time, it should have accruied 10 ether
         vm.warp(block.timestamp + 5);
-        available_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = erc20StreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 10 ether, "After 10 seconds, 10 ether should be available");
     }
 
-    ////////////////////// Simulation Tests //////////////////////
+    /**
+     * @notice Tests it fails with invalid call type singleDefaultMode (batch instead of single singleDefaultMode)
+     */
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
 
-    /// @notice Tests simulation of getAvailableAmount before and after the start date.
-    ///         Initially, when the start date is in the future, the available_ amount is zero.
-    ///         After warping time past the start date, the available_ amount increments
-    function test_getAvailableAmountSimulationBeforeInitialization() public {
-        // Set start date in the future.
-        uint256 futureStart_ = block.timestamp + 100;
-        bytes memory terms_ = _encodeTerms(address(basicERC20), 8 ether, 50 ether, 2 ether, futureStart_);
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
 
-        // Before the start date, available_ amount should be 0.
-        uint256 availableBefore_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
-        assertEq(availableBefore_, 0, "Available amount should be zero before start date");
-
-        // Warp time to after the future start date.
-        vm.warp(futureStart_ + 2);
-
-        // Now, with no claims, available_ amount should equal periodAmount.
-        uint256 availableAfter_ = erc20StreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
-        assertEq(availableAfter_, 8 ether + 4 ether, "Available amount should equal periodAmount after start date");
+        erc20StreamingEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     ////////////////////// Integration //////////////////////
@@ -411,15 +396,15 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         // rate = 2 ether per second,
         // startTime = current block timestamp.
         uint256 startTime = block.timestamp;
-        bytes memory terms_ = _encodeTerms(address(basicERC20), 5 ether, 20 ether, 2 ether, startTime);
+        bytes memory terms = _encodeTerms(address(basicERC20), 5 ether, 20 ether, 2 ether, startTime);
 
         // Create a caveat that uses the native token streaming enforcer.
-        Caveat[] memory caveats_ = new Caveat[](1);
-        caveats_[0] = Caveat({ args: hex"", enforcer: address(erc20StreamingEnforcer), terms: terms_ });
+        Caveat[] memory caveats = new Caveat[](1);
+        caveats[0] = Caveat({ args: hex"", enforcer: address(erc20StreamingEnforcer), terms: terms });
 
         // Build a delegation using the caveats array.
         Delegation memory delegation =
-            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats_, salt: 0, signature: hex"" });
+            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats, salt: 0, signature: hex"" });
         delegation = signDelegation(users.alice, delegation);
         delegationHash = EncoderLib._getDelegationHash(delegation);
 
@@ -439,22 +424,18 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         balanceCarol += 3 ether;
         assertEq(basicERC20.balanceOf(carol), balanceCarol, "Carol should have received 3 ether");
 
-        {
-            // At this point, the enforcer should have recorded 3 ether as spent.
-            (uint256 storedInitial, uint256 storedMax, uint256 storedRate, uint256 storedStart, uint256 storedSpent) =
-                erc20StreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
-            assertEq(storedInitial, 5 ether, "Initial amount should be 5 ether");
-            assertEq(storedMax, 20 ether, "Max amount should be 20 ether");
-            assertEq(storedRate, 2 ether, "Stored rate should be 2 ether");
-            assertEq(storedStart, startTime, "Stored start should be startTime");
-            assertEq(storedSpent, 3 ether, "Spent should be 3 ether after first op");
-        }
+        // At this point, the enforcer should have recorded 3 ether as spent.
+        (uint256 storedInitial, uint256 storedMax, uint256 storedRate, uint256 storedStart, uint256 storedSpent) =
+            erc20StreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
+        assertEq(storedInitial, 5 ether, "Initial amount should be 5 ether");
+        assertEq(storedMax, 20 ether, "Max amount should be 20 ether");
+        assertEq(storedRate, 2 ether, "Stored rate should be 2 ether");
+        assertEq(storedStart, startTime, "Stored start should be startTime");
+        assertEq(storedSpent, 3 ether, "Spent should be 3 ether after first op");
+
         // The unlocked amount at startTime is initial (5 ether), so available should be 5-3 = 2 ether.
-        assertEq(
-            erc20StreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_),
-            2 ether,
-            "Available should be 2 ether after first op"
-        );
+        uint256 availableAfter1 = erc20StreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
+        assertEq(availableAfter1, 2 ether, "Available should be 2 ether after first op");
 
         // --- Second UserOp: Transfer 4 native tokens after time warp ---
         // Warp forward 5 seconds. Now unlocked = 5 + (2 * 5) = 15 ether, cap is 20.
@@ -475,7 +456,7 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         assertEq(spentAfter2, 7 ether, "Spent should be 7 ether after second op");
 
         // Available should now be unlocked (15) - spent (7) = 8 ether.
-        uint256 availableAfter2 = erc20StreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_);
+        uint256 availableAfter2 = erc20StreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
         assertEq(availableAfter2, 8 ether, "Available should be 8 ether after second op");
     }
 
@@ -488,13 +469,13 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         // Set streaming terms:
         // initial = 5 ether, max = 5 ether (so no accrual beyond startTime), rate = 1 ether/sec.
         uint256 startTime = block.timestamp;
-        bytes memory terms_ = _encodeTerms(address(basicERC20), 5 ether, 5 ether, 1 ether, startTime);
+        bytes memory terms = _encodeTerms(address(basicERC20), 5 ether, 5 ether, 1 ether, startTime);
 
         // Create caveats and delegation
-        Caveat[] memory caveats_ = new Caveat[](1);
-        caveats_[0] = Caveat({ args: hex"", enforcer: address(erc20StreamingEnforcer), terms: terms_ });
+        Caveat[] memory caveats = new Caveat[](1);
+        caveats[0] = Caveat({ args: hex"", enforcer: address(erc20StreamingEnforcer), terms: terms });
         Delegation memory delegation =
-            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats_, salt: 0, signature: hex"" });
+            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats, salt: 0, signature: hex"" });
         delegation = signDelegation(users.alice, delegation);
         delegationHash = EncoderLib._getDelegationHash(delegation);
 
@@ -512,12 +493,13 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         assertEq(basicERC20.balanceOf(carol), balanceCarol, "Carol should have received 5 ether");
 
         // Now the allowance is fully consumed (spent == max = 5 ether). Available = 0.
-        uint256 available = erc20StreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_);
+        uint256 available = erc20StreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
         assertEq(available, 0, "Available should be 0 after full consumption");
 
         // Next, attempt another native token transfer of 1 ether.
         callData_ = _encodeERC20Transfer(carol, 1 ether);
         Execution memory execution2 = Execution({ target: address(basicERC20), value: 0, callData: callData_ });
+        // vm.expectRevert(bytes("erc20StreamingEnforcer:allowance-exceeded"));
         invokeDelegation_UserOp(users.bob, delegations, execution2);
 
         assertEq(basicERC20.balanceOf(carol), balanceCarol, "Carol should not have received anything");

--- a/test/enforcers/ERC721BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC721BalanceGteEnforcer.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicCF721 } from "../utils/BasicCF721.t.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 
 import "../../src/utils/Types.sol";
 import { Execution } from "../../src/utils/Types.sol";
@@ -20,7 +19,6 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
     address dm;
     Execution mintExecution;
     bytes mintExecutionCallData;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -58,19 +56,19 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 1
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.prank(delegator);
         token.mint(delegator);
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // Increase by 2
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.prank(delegator);
         token.mint(delegator);
         vm.prank(dm);
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     ////////////////////// Errors //////////////////////
@@ -82,11 +80,11 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // No increase
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         // No minting occurs here
         vm.prank(dm);
         vm.expectRevert(bytes("ERC721BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Reverts if a balance decreased in between the hooks
@@ -99,7 +97,7 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), uint256(1));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // Decrease balance by transferring token away
         uint256 tokenIdToTransfer_ = (token.tokenId()) - 1;
@@ -108,7 +106,7 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert(bytes("ERC721BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Allows to check the balance of different recipients
@@ -123,11 +121,11 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
             // Increase by 1 for each recipient
             vm.prank(dm);
-            enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(i), address(0), delegate);
+            enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(i), address(0), delegate);
             vm.prank(delegator);
             token.mint(currentRecipient_);
             vm.prank(dm);
-            enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(i), address(0), delegate);
+            enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(i), address(0), delegate);
         }
     }
 
@@ -141,13 +139,13 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), uint256(1));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
 
         // No increase occurs here
 
         vm.prank(dm);
         vm.expectRevert(bytes("ERC721BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Same delegation hash multiple recipients
@@ -159,10 +157,10 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms2_ = abi.encodePacked(address(token), recipient2_, uint256(1));
 
         vm.prank(dm);
-        enforcer.beforeHook(terms1_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         vm.prank(dm);
-        enforcer.beforeHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // Increase balance by 1 only in recipient1
         vm.prank(delegator);
@@ -170,12 +168,12 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // This one works well recipient1 increased
         vm.prank(dm);
-        enforcer.afterHook(terms1_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms1_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // This one fails recipient2 didn't increase
         vm.prank(dm);
         vm.expectRevert(bytes("ERC721BalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
 
         // Increase balance by 1 in recipient2 to fix it
         vm.prank(delegator);
@@ -183,7 +181,7 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Recipient2 works well
         vm.prank(dm);
-        enforcer.afterHook(terms2_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms2_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
     }
 
     // Reverts if the enforcer is locked
@@ -194,11 +192,11 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Lock the enforcer
         vm.startPrank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         bytes32 hashKey_ = enforcer.getHashKey(address(delegationManager), address(token), address(delegator), delegationHash_);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.expectRevert(bytes("ERC721BalanceGteEnforcer:enforcer-is-locked"));
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         vm.stopPrank();
 
         vm.prank(delegator);
@@ -206,10 +204,10 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.startPrank(dm);
         // Unlock the enforcer
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         assertFalse(enforcer.isLocked(hashKey_));
         // Can be used again, and locks it again
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, delegationHash_, address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, delegationHash_, address(0), delegate);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.stopPrank();
     }
@@ -236,7 +234,7 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         // Invalid token address
         terms_ = abi.encodePacked(address(0), address(delegator), uint256(1));
         vm.expectRevert();
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     // Validates that an unrealistic amount causes a revert
@@ -245,9 +243,9 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(token), address(delegator), type(uint256).max);
 
         vm.prank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
         vm.expectRevert();
-        enforcer.afterHook(terms_, hex"", mode, mintExecutionCallData, bytes32(0), address(0), delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
     //////////////////////  Integration  //////////////////////

--- a/test/enforcers/ERC721TransferEnforcer.t.sol
+++ b/test/enforcers/ERC721TransferEnforcer.t.sol
@@ -2,23 +2,19 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { BasicCF721 } from "../utils/BasicCF721.t.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ERC721TransferEnforcer } from "../../src/enforcers/ERC721TransferEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////// State //////////////////////
 
     ERC721TransferEnforcer public erc721TransferEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
     uint256 public constant TOKEN_ID = 0;
     BasicCF721 public token;
 
@@ -49,7 +45,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -64,7 +66,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -81,7 +89,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -105,7 +119,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("ERC721TransferEnforcer:unauthorized-contract-target");
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -119,7 +139,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("ERC721TransferEnforcer:unauthorized-selector");
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -135,7 +161,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("ERC721TransferEnforcer:unauthorized-token-id");
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
     }
 
@@ -151,8 +183,23 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("ERC721TransferEnforcer:invalid-calldata-length");
         erc721TransferEnforcer.beforeHook(
-            abi.encodePacked(address(token), TOKEN_ID), hex"", mode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encodePacked(address(token), TOKEN_ID),
+            hex"",
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
+    }
+
+    // should fail with invalid call type mode (batch instead of single mode)
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        erc721TransferEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     ////////////////////// Integration //////////////////////

--- a/test/enforcers/ExactCalldataBatchEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataBatchEnforcer.t.sol
@@ -149,15 +149,30 @@ contract ExactCalldataBatchEnforcerTest is CaveatEnforcerBaseTest {
     }
 
     // should fail with invalid call type mode (single mode instead of batch)
-    function test_revertWithInvalidMode() public {
+    function test_revertWithInvalidCallTypeMode() public {
         Execution[] memory executions_ = new Execution[](2);
-        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
         bytes memory terms_ = _encodeTerms(executions_);
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
 
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-call-type");
         exactCalldataBatchEnforcer.beforeHook(
             terms_, hex"", singleDefaultMode, executionCallData_, keccak256("test"), address(0), address(0)
+        );
+    }
+
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        Execution[] memory executions_ = new Execution[](2);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        exactCalldataBatchEnforcer.beforeHook(
+            terms_, hex"", batchTryMode, executionCallData_, keccak256("test"), address(0), address(0)
         );
     }
 

--- a/test/enforcers/ExactCalldataEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataEnforcer.t.sol
@@ -2,22 +2,18 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ExactCalldataEnforcer } from "../../src/enforcers/ExactCalldataEnforcer.sol";
 import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     ExactCalldataEnforcer public exactCalldataEnforcer;
     BasicERC20 public basicCF20;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////////////// Setup //////////////////////////////
     function setUp() public override {
@@ -43,7 +39,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = execution_.callData;
 
         vm.prank(address(delegationManager));
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer reverts when the executed calldata does not exactly match the expected calldata.
@@ -60,7 +58,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         vm.expectRevert("ExactCalldataEnforcer:invalid-calldata");
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer works correctly with a dynamic array parameter.
@@ -78,7 +78,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = execution_.callData;
 
         vm.prank(address(delegationManager));
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer works correctly with a dynamic string parameter.
@@ -91,7 +93,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = execution_.callData;
 
         vm.prank(address(delegationManager));
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer passes when both expected and execution calldata are empty (ETH transfer).
@@ -103,7 +107,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = "";
 
         vm.prank(address(delegationManager));
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer reverts when expected calldata is empty but execution calldata is non-empty.
@@ -116,7 +122,9 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(address(delegationManager));
         vm.expectRevert("ExactCalldataEnforcer:invalid-calldata");
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
     }
 
     /// @notice Test that the enforcer reverts when batch-encoded execution calldata is provided.
@@ -131,7 +139,18 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         // Expect a revert because the enforcer calls decodeSingle() on batch encoded calldata.
         vm.expectRevert();
-        exactCalldataEnforcer.beforeHook(terms_, hex"", mode, batchEncodedCallData_, keccak256(""), address(0), address(0));
+        exactCalldataEnforcer.beforeHook(
+            terms_, hex"", singleDefaultMode, batchEncodedCallData_, keccak256(""), address(0), address(0)
+        );
+    }
+
+    // should fail with invalid call type mode (batch instead of single mode)
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        exactCalldataEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     ////////////////////////////// Integration Tests //////////////////////////////

--- a/test/enforcers/ExactExecutionBatchEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionBatchEnforcer.t.sol
@@ -204,15 +204,30 @@ contract ExactExecutionBatchEnforcerTest is CaveatEnforcerBaseTest {
     }
 
     // should fail with invalid call type mode (single mode instead of batch)
-    function test_revertWithInvalidMode() public {
+    function test_revertWithInvalidCallTypeMode() public {
         Execution[] memory executions_ = new Execution[](2);
-        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
         bytes memory terms_ = _encodeTerms(executions_);
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
 
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-call-type");
         exactExecutionBatchEnforcer.beforeHook(
             terms_, hex"", singleDefaultMode, executionCallData_, keccak256("test"), address(0), address(0)
+        );
+    }
+
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        Execution[] memory executions_ = new Execution[](2);
+        bytes memory terms_ = _encodeTerms(executions_);
+
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        exactExecutionBatchEnforcer.beforeHook(
+            terms_, hex"", batchTryMode, executionCallData_, keccak256("test"), address(0), address(0)
         );
     }
 

--- a/test/enforcers/IdEnforcer.t.sol
+++ b/test/enforcers/IdEnforcer.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import "../../src/utils/Types.sol";
@@ -16,12 +15,9 @@ import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
 
 contract IdEnforcerEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     IdEnforcer public idEnforcer;
     BasicERC20 public testFToken1;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
     address public redeemer = address(users.bob.deleGator);
 
     ////////////////////////////// Events //////////////////////////////
@@ -58,7 +54,7 @@ contract IdEnforcerEnforcerTest is CaveatEnforcerBaseTest {
         // First usage works well
         vm.expectEmit(true, true, true, true, address(idEnforcer));
         emit IdEnforcer.UsedId(address(delegationManager), delegator_, redeemer, id_);
-        idEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, bytes32(0), delegator_, redeemer);
+        idEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), delegator_, redeemer);
 
         // After the first usage the enforcer marks the nonce as used.
         assertTrue(idEnforcer.getIsUsed(address(delegationManager), delegator_, id_));
@@ -66,7 +62,7 @@ contract IdEnforcerEnforcerTest is CaveatEnforcerBaseTest {
         // Second usage reverts, and returns false.
         vm.expectRevert("IdEnforcer:id-already-used");
 
-        idEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, bytes32(0), delegator_, redeemer);
+        idEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), delegator_, redeemer);
     }
 
     // should FAIL to INVOKE with invalid input terms
@@ -75,11 +71,11 @@ contract IdEnforcerEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
         bytes memory terms_ = abi.encodePacked(uint32(1));
         vm.expectRevert("IdEnforcer:invalid-terms-length");
-        idEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, bytes32(0), address(0), redeemer);
+        idEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), address(0), redeemer);
 
         terms_ = abi.encodePacked(uint256(1), uint256(1));
         vm.expectRevert("IdEnforcer:invalid-terms-length");
-        idEnforcer.beforeHook(terms_, hex"", mode, executionCallData_, bytes32(0), address(0), redeemer);
+        idEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), address(0), redeemer);
     }
 
     //////////////////////  Integration  //////////////////////

--- a/test/enforcers/NativeBalanceGteEnforcer.t.sol
+++ b/test/enforcers/NativeBalanceGteEnforcer.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 pragma solidity 0.8.23;
 
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
-
 import "../../src/utils/Types.sol";
 import { Execution } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
@@ -11,8 +9,6 @@ import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { Counter } from "../utils/Counter.t.sol";
 
 contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     NativeBalanceGteEnforcer public enforcer;
     address delegator;
@@ -20,7 +16,6 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
     address dm;
     Execution noExecution;
     bytes executionCallData = abi.encode(noExecution);
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -54,14 +49,14 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 100
         vm.startPrank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
         _increaseBalance(delegator, 100);
-        enforcer.afterHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
 
         // Increase by 1000
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
         _increaseBalance(delegator, 1000);
-        enforcer.afterHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
     }
 
     // ////////////////////// Errors //////////////////////
@@ -74,10 +69,10 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Increase by 10, expect revert
         vm.startPrank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
         _increaseBalance(delegator, 10);
         vm.expectRevert(bytes("NativeBalanceGteEnforcer:balance-not-gt"));
-        enforcer.afterHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
     }
 
     // Reverts if a enforcer is locked
@@ -90,19 +85,19 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         // Increase by 100
         vm.startPrank(dm);
         // Locks the enforcer
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
         bytes32 hashKey_ = enforcer.getHashKey(address(delegationManager), delegationHash_);
         assertTrue(enforcer.isLocked(hashKey_));
         vm.expectRevert(bytes("NativeBalanceGteEnforcer:enforcer-is-locked"));
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
         _increaseBalance(delegator, 1000);
         vm.startPrank(dm);
 
         // Unlocks the enforcer
-        enforcer.afterHook(terms_, hex"", mode, executionCallData, delegationHash_, delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
         assertFalse(enforcer.isLocked(hashKey_));
         // Can be used again, and locks it again
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, delegationHash_, delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
         assertTrue(enforcer.isLocked(hashKey_));
     }
 
@@ -130,9 +125,9 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(recipient_, type(uint256).max);
         vm.deal(recipient_, type(uint256).max);
         vm.startPrank(dm);
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
         vm.expectRevert();
-        enforcer.afterHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, delegate);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
     }
 
     function _increaseBalance(address _recipient, uint256 _amount) internal {

--- a/test/enforcers/NativeTokenPaymentEnforcer.t.sol
+++ b/test/enforcers/NativeTokenPaymentEnforcer.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 pragma solidity 0.8.23;
 
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
@@ -17,8 +16,6 @@ import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { Counter } from "../utils/Counter.t.sol";
 
 contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////// Set up //////////////////////
     NativeTokenPaymentEnforcer public nativeTokenPaymentEnforcer;
     NativeTokenTransferAmountEnforcer public nativeTokenTransferAmountEnforcer;
@@ -36,7 +33,6 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
     bytes public allowanceTerms;
     bytes public argsEnforcerTerms;
     bytes public argsWithBobAllowance;
-    ModeCode public modeSimpleSingle = ModeLib.encodeSimpleSingle();
 
     function setUp() public override {
         super.setUp();
@@ -107,7 +103,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            modeSimpleSingle,
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(users.alice.deleGator),
@@ -162,7 +158,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            modeSimpleSingle,
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(users.alice.deleGator),
@@ -220,7 +216,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            ModeLib.encodeSimpleSingle(),
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(users.alice.deleGator),
@@ -268,7 +264,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            ModeLib.encodeSimpleSingle(),
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(users.alice.deleGator),
@@ -292,7 +288,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            ModeLib.encodeSimpleSingle(),
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(users.alice.deleGator),
@@ -322,7 +318,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            modeSimpleSingle,
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(0),
@@ -358,7 +354,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            modeSimpleSingle,
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(0),
@@ -389,7 +385,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            modeSimpleSingle,
+            singleDefaultMode,
             executionCalldata,
             delegationHash_,
             address(0),
@@ -402,9 +398,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         // Using an invalid sender, it must be the delegation manager
         vm.startPrank(address(users.bob.deleGator));
         vm.expectRevert("NativeTokenPaymentEnforcer:only-delegation-manager");
-        nativeTokenPaymentEnforcer.afterAllHook(
-            hex"", hex"", ModeLib.encodeSimpleSingle(), new bytes(0), bytes32(0), address(0), address(0)
-        );
+        nativeTokenPaymentEnforcer.afterAllHook(hex"", hex"", singleDefaultMode, new bytes(0), bytes32(0), address(0), address(0));
     }
 
     // Should SUCCEED to charge the payment from the allowance delegation
@@ -566,7 +560,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            ModeLib.encodeSimpleSingle(),
+            singleDefaultMode,
             executionCalldata,
             maliciousDelegationHash_,
             maliciousPaidDelegation_.delegator,
@@ -577,7 +571,7 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         nativeTokenPaymentEnforcer.afterAllHook(
             paymentTerms,
             argsWithBobAllowance,
-            ModeLib.encodeSimpleSingle(),
+            singleDefaultMode,
             executionCalldata,
             originalDelegationHash_,
             originalPaidDelegation_.delegator,

--- a/test/enforcers/NativeTokenStreamingEnforcer.t.sol
+++ b/test/enforcers/NativeTokenStreamingEnforcer.t.sol
@@ -2,21 +2,17 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { ModeCode, Caveat, Delegation, Execution } from "../../src/utils/Types.sol";
+import { Caveat, Delegation, Execution } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { NativeTokenStreamingEnforcer } from "../../src/enforcers/NativeTokenStreamingEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
 
 contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     NativeTokenStreamingEnforcer public nativeTokenStreamingEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
     address public alice;
     address public bob;
     address public carol;
@@ -45,7 +41,7 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeNativeTokenExecution(10 ether);
 
         vm.expectRevert(bytes("NativeTokenStreamingEnforcer:invalid-terms-length"));
-        nativeTokenStreamingEnforcer.beforeHook(badTerms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(badTerms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -63,7 +59,7 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeNativeTokenExecution(10 ether);
 
         vm.expectRevert(bytes("NativeTokenStreamingEnforcer:invalid-max-amount"));
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -82,7 +78,7 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeNativeTokenExecution(10 ether);
 
         vm.expectRevert(bytes("NativeTokenStreamingEnforcer:invalid-zero-start-time"));
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -102,7 +98,20 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory execData_ = _encodeNativeTokenExecution(10 ether);
 
         vm.expectRevert(bytes("NativeTokenStreamingEnforcer:allowance-exceeded"));
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
+    }
+
+    /**
+     * @notice should fail with invalid call type mode (batch instead of single singleDefaultMode)
+     */
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        nativeTokenStreamingEnforcer.beforeHook(
+            hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0)
+        );
     }
 
     //////////////////// Valid cases //////////////////////
@@ -163,17 +172,17 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
             block.timestamp
         );
 
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // Verify final storage
-        (uint256 storedInit_, uint256 storedMax__, uint256 storedRate__, uint256 storedStart__, uint256 storedSpent__) =
+        (uint256 storedInit_, uint256 storedMax_, uint256 storedRate_, uint256 storedStart_, uint256 storedSpent_) =
             nativeTokenStreamingEnforcer.streamingAllowances(address(this), bytes32(0));
 
         assertEq(storedInit_, initialAmount_, "Initial amount not stored correctly");
-        assertEq(storedMax__, maxAmount_, "Max amount not stored correctly");
-        assertEq(storedRate__, amountPerSecond_, "Rate not stored correctly");
-        assertEq(storedStart__, startTime_, "Start time not stored correctly");
-        assertEq(storedSpent__, transferAmount_, "Spent amount not updated correctly");
+        assertEq(storedMax_, maxAmount_, "Max amount not stored correctly");
+        assertEq(storedRate_, amountPerSecond_, "Rate not stored correctly");
+        assertEq(storedStart_, startTime_, "Start time not stored correctly");
+        assertEq(storedSpent_, transferAmount_, "Spent amount not updated correctly");
     }
 
     /**
@@ -188,10 +197,10 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
 
         // Calls beforeHook expecting no tokens to be spendable => must revert
         vm.expectRevert("NativeTokenStreamingEnforcer:allowance-exceeded");
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // Checking getAvailableAmount directly also returns 0
-        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Expected 0 tokens available before startTime");
     }
 
@@ -207,7 +216,7 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
             block.timestamp
         );
 
-        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Should have 0 tokens available initially");
 
         // After 3 seconds => 3 unlocked (since initial=0)
@@ -215,15 +224,15 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
 
         // Transfer 2 => ok
         bytes memory execData_ = _encodeNativeTokenExecution(2 ether);
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // 3 were unlocked, spent=2 => 1 left
-        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 1 ether, "Expected 1 ether remaining after transfer");
 
         // Another 10 seconds => total unlocked=3+10=13, but clamp at max=5 => total=5 => spent=2 => 3 left
         vm.warp(block.timestamp + 10);
-        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 3 ether, "Expected 3 ether remaining after clamping at max");
     }
 
@@ -235,26 +244,26 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         // initial=10 => available at startTime, rate=2 => 2 tokens added each second, up to max=20
 
         uint256 startTime_ = block.timestamp;
-        bytes memory terms_ = _encodeTerms(10 ether, 20 ether, 2 ether, startTime_);
+        bytes memory terms = _encodeTerms(10 ether, 20 ether, 2 ether, startTime_);
 
         // Transfer 5 immediately => 5 left (spent=5)
         bytes memory execData_ = _encodeNativeTokenExecution(5 ether);
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // spent=5, unlocked=10 => 5 remain
-        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 5 ether, "Expected 5 ether remaining from initial chunk after spending 5");
 
         // warp 5 seconds => totalUnlocked=10 + (2*5)=20 => at or beyond max=20 => clamp=20 => spent=5 => 15 left
         vm.warp(block.timestamp + 5);
-        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 15 ether, "Expected 15 ether remaining after accrual, clamped at 20");
 
         // Transfer 15 => total spent=20 => 0 remain
         execData_ = _encodeNativeTokenExecution(15 ether);
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
-        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "Expected 0 remaining after full consumption");
     }
 
@@ -271,13 +280,13 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
 
         // Transfer the full 5 => should succeed
         bytes memory execData_ = _encodeNativeTokenExecution(5 ether);
-        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
         // Now spent == maxAmount (5). No more tokens remain.
         // Another attempt to transfer any positive amount should revert
         execData_ = _encodeNativeTokenExecution(1 ether);
         vm.expectRevert(bytes("NativeTokenStreamingEnforcer:allowance-exceeded"));
-        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
     }
 
     /**
@@ -290,37 +299,15 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         vm.warp(startTime_);
 
         bytes memory execData_ = _encodeNativeTokenExecution(8 ether);
-        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), mode, execData_, bytes32(0), address(0), alice);
+        nativeTokenStreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
 
-        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 0, "After transferring the initial amount 8 ether, 0 should remain at start date");
 
         // 5 seconds after start time, it should have accruied 10 ether
         vm.warp(block.timestamp + 5);
-        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
+        available_ = nativeTokenStreamingEnforcer.getAvailableAmount(address(this), bytes32(0));
         assertEq(available_, 10 ether, "After 10 seconds, 10 ether should be available");
-    }
-
-    ////////////////////// Simulation Tests //////////////////////
-
-    /// @notice Tests simulation of getAvailableAmount before and after the start date.
-    ///         Initially, when the start date is in the future, the available_ amount is zero.
-    ///         After warping time past the start date, the available_ amount increments
-    function test_getAvailableAmountSimulationBeforeInitialization() public {
-        // Set start date in the future.
-        uint256 futureStart_ = block.timestamp + 100;
-        bytes memory terms_ = _encodeTerms(8 ether, 50 ether, 2 ether, futureStart_);
-
-        // Before the start date, available_ amount should be 0.
-        uint256 availableBefore_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
-        assertEq(availableBefore_, 0, "Available amount should be zero before start date");
-
-        // Warp time to after the future start date.
-        vm.warp(futureStart_ + 2);
-
-        // Now, with no claims, available_ amount should equal periodAmount.
-        uint256 availableAfter_ = nativeTokenStreamingEnforcer.getAvailableAmount(bytes32(0), address(this), terms_);
-        assertEq(availableAfter_, 8 ether + 4 ether, "Available amount should equal periodAmount after start date");
     }
 
     ////////////////////// Integration //////////////////////
@@ -337,74 +324,71 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         // max = 20 ether (the cap),
         // rate = 2 ether per second,
         // startTime = current block timestamp.
-        uint256 startTime_ = block.timestamp;
-        bytes memory terms_ = _encodeTerms(5 ether, 20 ether, 2 ether, startTime_);
+        uint256 startTime = block.timestamp;
+        bytes memory terms = _encodeTerms(5 ether, 20 ether, 2 ether, startTime);
 
         // Create a caveat that uses the native token streaming enforcer.
-        Caveat[] memory caveats_ = new Caveat[](1);
-        caveats_[0] = Caveat({ args: hex"", enforcer: address(nativeTokenStreamingEnforcer), terms: terms_ });
+        Caveat[] memory caveats = new Caveat[](1);
+        caveats[0] = Caveat({ args: hex"", enforcer: address(nativeTokenStreamingEnforcer), terms: terms });
 
         // Build a delegation using the caveats array.
-        Delegation memory delegation_ =
-            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats_, salt: 0, signature: hex"" });
-        delegation_ = signDelegation(users.alice, delegation_);
-        bytes32 delegationHash = EncoderLib._getDelegationHash(delegation_);
+        Delegation memory delegation =
+            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats, salt: 0, signature: hex"" });
+        delegation = signDelegation(users.alice, delegation);
+        bytes32 delegationHash = EncoderLib._getDelegationHash(delegation);
 
-        Delegation[] memory delegations_ = new Delegation[](1);
-        delegations_[0] = delegation_;
+        Delegation[] memory delegations = new Delegation[](1);
+        delegations[0] = delegation;
 
-        uint256 balanceCarol_ = carol.balance;
+        uint256 balanceCarol = carol.balance;
 
         // --- First UserOp: Transfer 3 native tokens ---
         // Create an execution that represents a native token transfer of 3 ether to Carol
-        Execution memory execution1_ = Execution({
+        Execution memory execution1 = Execution({
             target: carol,
             value: 3 ether,
             callData: "" // no callData needed for native token transfer
          });
 
         // Invoke the delegation user op.
-        invokeDelegation_UserOp(users.bob, delegations_, execution1_);
+        invokeDelegation_UserOp(users.bob, delegations, execution1);
 
-        balanceCarol_ += 3 ether;
-        assertEq(carol.balance, balanceCarol_, "Carol should have received 3 ether");
-        {
-            // At this point, the enforcer should have recorded 3 ether as spent.
-            (uint256 storedInitial_, uint256 storedMax_, uint256 storedRate_, uint256 storedStart_, uint256 storedSpent_) =
-                nativeTokenStreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
-            assertEq(storedInitial_, 5 ether, "Initial amount should be 5 ether");
-            assertEq(storedMax_, 20 ether, "Max amount should be 20 ether");
-            assertEq(storedRate_, 2 ether, "Stored rate should be 2 ether");
-            assertEq(storedStart_, startTime_, "Stored start should be startTime");
-            assertEq(storedSpent_, 3 ether, "Spent should be 3 ether after first op");
-        }
+        balanceCarol += 3 ether;
+        assertEq(carol.balance, balanceCarol, "Carol should have received 3 ether");
+
+        // At this point, the enforcer should have recorded 3 ether as spent.
+        (uint256 storedInitial, uint256 storedMax, uint256 storedRate, uint256 storedStart, uint256 storedSpent) =
+            nativeTokenStreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
+        assertEq(storedInitial, 5 ether, "Initial amount should be 5 ether");
+        assertEq(storedMax, 20 ether, "Max amount should be 20 ether");
+        assertEq(storedRate, 2 ether, "Stored rate should be 2 ether");
+        assertEq(storedStart, startTime, "Stored start should be startTime");
+        assertEq(storedSpent, 3 ether, "Spent should be 3 ether after first op");
 
         // The unlocked amount at startTime is initial (5 ether), so available should be 5-3 = 2 ether.
-        uint256 availableAfter1_ =
-            nativeTokenStreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_);
-        assertEq(availableAfter1_, 2 ether, "Available should be 2 ether after first op");
+        uint256 availableAfter1 = nativeTokenStreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
+        assertEq(availableAfter1, 2 ether, "Available should be 2 ether after first op");
 
         // --- Second UserOp: Transfer 4 native tokens after time warp ---
         // Warp forward 5 seconds. Now unlocked = 5 + (2 * 5) = 15 ether, cap is 20.
         vm.warp(block.timestamp + 5);
 
         // Create an execution for transferring 4 ether.
-        Execution memory execution2_ = Execution({ target: carol, value: 4 ether, callData: "" });
+        Execution memory execution2 = Execution({ target: carol, value: 4 ether, callData: "" });
 
         // Invoke the user op.
-        invokeDelegation_UserOp(users.bob, delegations_, execution2_);
+        invokeDelegation_UserOp(users.bob, delegations, execution2);
 
-        balanceCarol_ += 4 ether;
-        assertEq(carol.balance, balanceCarol_, "Carol should have received 4 ether");
+        balanceCarol += 4 ether;
+        assertEq(carol.balance, balanceCarol, "Carol should have received 4 ether");
 
         // Total spent should now be 3 + 4 = 7 ether.
-        (,,,, uint256 spentAfter2_) = nativeTokenStreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
-        assertEq(spentAfter2_, 7 ether, "Spent should be 7 ether after second op");
+        (,,,, uint256 spentAfter2) = nativeTokenStreamingEnforcer.streamingAllowances(address(delegationManager), delegationHash);
+        assertEq(spentAfter2, 7 ether, "Spent should be 7 ether after second op");
 
         // Available should now be unlocked (15) - spent (7) = 8 ether.
-        uint256 availableAfter2_ =
-            nativeTokenStreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_);
-        assertEq(availableAfter2_, 8 ether, "Available should be 8 ether after second op");
+        uint256 availableAfter2 = nativeTokenStreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
+        assertEq(availableAfter2, 8 ether, "Available should be 8 ether after second op");
     }
 
     /**
@@ -415,36 +399,36 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
     function test_nativeTokenStreamingIntegration_ExceedsAllowance() public {
         // Set streaming terms:
         // initial = 5 ether, max = 5 ether (so no accrual beyond startTime), rate = 1 ether/sec.
-        uint256 startTime_ = block.timestamp;
-        bytes memory terms_ = _encodeTerms(5 ether, 5 ether, 1 ether, startTime_);
+        uint256 startTime = block.timestamp;
+        bytes memory terms = _encodeTerms(5 ether, 5 ether, 1 ether, startTime);
 
         // Create caveats and delegation
-        Caveat[] memory caveats_ = new Caveat[](1);
-        caveats_[0] = Caveat({ args: hex"", enforcer: address(nativeTokenStreamingEnforcer), terms: terms_ });
-        Delegation memory delegation_ =
-            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats_, salt: 0, signature: hex"" });
-        delegation_ = signDelegation(users.alice, delegation_);
-        bytes32 delegationHash = EncoderLib._getDelegationHash(delegation_);
+        Caveat[] memory caveats = new Caveat[](1);
+        caveats[0] = Caveat({ args: hex"", enforcer: address(nativeTokenStreamingEnforcer), terms: terms });
+        Delegation memory delegation =
+            Delegation({ delegate: bob, delegator: alice, authority: ROOT_AUTHORITY, caveats: caveats, salt: 0, signature: hex"" });
+        delegation = signDelegation(users.alice, delegation);
+        bytes32 delegationHash = EncoderLib._getDelegationHash(delegation);
 
-        Delegation[] memory delegations_ = new Delegation[](1);
-        delegations_[0] = delegation_;
+        Delegation[] memory delegations = new Delegation[](1);
+        delegations[0] = delegation;
 
         uint256 balanceCarol = carol.balance;
 
         // First, invoke a user op to transfer the full 5 ether.
-        Execution memory execution1_ = Execution({ target: carol, value: 5 ether, callData: "" });
-        invokeDelegation_UserOp(users.bob, delegations_, execution1_);
+        Execution memory execution1 = Execution({ target: carol, value: 5 ether, callData: "" });
+        invokeDelegation_UserOp(users.bob, delegations, execution1);
 
         balanceCarol += 5 ether;
         assertEq(carol.balance, balanceCarol, "Carol should have received 5 ether");
 
         // Now the allowance is fully consumed (spent == max = 5 ether). Available = 0.
-        uint256 available_ = nativeTokenStreamingEnforcer.getAvailableAmount(delegationHash, address(delegationManager), terms_);
-        assertEq(available_, 0, "Available should be 0 after full consumption");
+        uint256 available = nativeTokenStreamingEnforcer.getAvailableAmount(address(delegationManager), delegationHash);
+        assertEq(available, 0, "Available should be 0 after full consumption");
 
         // Next, attempt another native token transfer of 1 ether.
-        Execution memory execution2_ = Execution({ target: carol, value: 1 ether, callData: "" });
-        invokeDelegation_UserOp(users.bob, delegations_, execution2_);
+        Execution memory execution2 = Execution({ target: carol, value: 1 ether, callData: "" });
+        invokeDelegation_UserOp(users.bob, delegations, execution2);
 
         assertEq(carol.balance, balanceCarol, "Carol should not have received anything");
     }

--- a/test/enforcers/NonceEnforcer.t.sol
+++ b/test/enforcers/NonceEnforcer.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import "../../src/utils/Types.sol";
@@ -12,15 +11,12 @@ import { NonceEnforcer } from "../../src/enforcers/NonceEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract NonceEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     NonceEnforcer public enforcer;
     Execution execution = Execution({ target: address(0), value: 0, callData: hex"" });
     bytes executionCallData = ExecutionLib.encodeSingle(execution.target, execution.value, execution.callData);
     address delegator = address(users.alice.deleGator);
     address dm = address(delegationManager);
-    ModeCode mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////////////// Events //////////////////////////////
 
@@ -72,7 +68,7 @@ contract NonceEnforcerTest is CaveatEnforcerBaseTest {
         vm.startPrank(dm);
 
         // Should not revert
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, address(0));
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, address(0));
     }
 
     ////////////////////// Errors //////////////////////
@@ -100,7 +96,7 @@ contract NonceEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encode(nonce_ + 1);
         vm.startPrank(dm);
         vm.expectRevert(bytes("NonceEnforcer:invalid-nonce"));
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, address(0));
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, address(0));
 
         // Increment ID so the current ID is high enough to check a lower ID
         vm.startPrank(dm);
@@ -111,7 +107,7 @@ contract NonceEnforcerTest is CaveatEnforcerBaseTest {
         terms_ = abi.encode(nonce_ - 1);
         vm.startPrank(dm);
         vm.expectRevert(bytes("NonceEnforcer:invalid-nonce"));
-        enforcer.beforeHook(terms_, hex"", mode, executionCallData, bytes32(0), delegator, address(0));
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, address(0));
     }
 
     //////////////////////  Integration  //////////////////////

--- a/test/enforcers/OwnershipTransferEnforcer.t.sol
+++ b/test/enforcers/OwnershipTransferEnforcer.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import "../../src/utils/Types.sol";
@@ -19,7 +18,6 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
     address dm;
     Execution transferOwnershipExecution;
     bytes transferOwnershipExecutionCallData;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -60,7 +58,7 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.expectEmit(true, true, true, true, address(enforcer));
         emit OwnershipTransferEnforcer.OwnershipTransferEnforced(dm, delegate, bytes32(0), newOwner);
-        enforcer.beforeHook(terms_, hex"", mode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     ////////////////////// Errors //////////////////////
@@ -87,7 +85,7 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert("OwnershipTransferEnforcer:invalid-contract");
-        enforcer.beforeHook(terms_, hex"", mode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Reverts if the method called is not transferOwnership
@@ -104,7 +102,7 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert("OwnershipTransferEnforcer:invalid-method");
-        enforcer.beforeHook(terms_, hex"", mode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
     }
 
     // Reverts if the execution call data length is invalid
@@ -121,10 +119,17 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
 
         vm.prank(dm);
         vm.expectRevert("OwnershipTransferEnforcer:invalid-execution-length");
-        enforcer.beforeHook(terms_, hex"", mode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
     }
 
-    //////////////////////  Integration  //////////////////////
+    // should fail with invalid call type mode (batch instead of single mode)
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        enforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/PasswordEnforcer.t.sol
+++ b/test/enforcers/PasswordEnforcer.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import "../../src/utils/Types.sol";
@@ -17,11 +16,8 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { SigningUtilsLib } from "../utils/SigningUtilsLib.t.sol";
 
 contract PasswordEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     PasswordEnforcer public passwordEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -41,7 +37,9 @@ contract PasswordEnforcerTest is CaveatEnforcerBaseTest {
         vm.startPrank(address(delegationManager));
 
         // First usage works well
-        passwordEnforcer.beforeHook(terms_, abi.encode(password_), mode, executionCallData_, bytes32(0), delegator_, address(0));
+        passwordEnforcer.beforeHook(
+            terms_, abi.encode(password_), singleDefaultMode, executionCallData_, bytes32(0), delegator_, address(0)
+        );
     }
 
     function test_userInputIncorrectArgs() public {
@@ -57,7 +55,7 @@ contract PasswordEnforcerTest is CaveatEnforcerBaseTest {
         vm.expectRevert("PasswordEnforcerError");
 
         passwordEnforcer.beforeHook(
-            terms_, abi.encode(incorrectPassword_), mode, executionCallData_, bytes32(0), delegator_, address(0)
+            terms_, abi.encode(incorrectPassword_), singleDefaultMode, executionCallData_, bytes32(0), delegator_, address(0)
         );
     }
 

--- a/test/enforcers/RedeemerEnforcer.t.sol
+++ b/test/enforcers/RedeemerEnforcer.t.sol
@@ -1,21 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
-import { Execution, ModeCode } from "../../src/utils/Types.sol";
+import { Execution } from "../../src/utils/Types.sol";
 import { Counter } from "../utils/Counter.t.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { RedeemerEnforcer } from "../../src/enforcers/RedeemerEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     RedeemerEnforcer public redeemerEnforcer;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////// Set up //////////////////////
 
@@ -47,7 +43,7 @@ contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(users.bob.deleGator));
         vm.prank(address(delegationManager));
         redeemerEnforcer.beforeHook(
-            terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
         );
     }
 
@@ -63,10 +59,10 @@ contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory terms_ = abi.encodePacked(address(users.alice.deleGator), address(users.bob.deleGator));
         vm.startPrank(address(delegationManager));
         redeemerEnforcer.beforeHook(
-            terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(users.alice.deleGator)
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(users.alice.deleGator)
         );
         redeemerEnforcer.beforeHook(
-            terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
         );
     }
 
@@ -92,7 +88,7 @@ contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
         // Dave is not a valid redeemer
         vm.expectRevert("RedeemerEnforcer:unauthorized-redeemer");
         redeemerEnforcer.beforeHook(
-            terms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(users.dave.deleGator)
+            terms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(users.dave.deleGator)
         );
     }
 
@@ -109,7 +105,7 @@ contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
         vm.prank(address(delegationManager));
         vm.expectRevert("RedeemerEnforcer:invalid-terms-length");
         redeemerEnforcer.beforeHook(
-            invalidTerms_, hex"", mode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
+            invalidTerms_, hex"", singleDefaultMode, executionCallData_, keccak256(""), address(0), address(users.bob.deleGator)
         );
     }
 

--- a/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
+++ b/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
@@ -71,13 +71,23 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
     ////////////////////// Invalid cases //////////////////////
 
     // should fail with invalid call type mode (single mode instead of batch)
-    function test_revertWithInvalidMode() public {
+    function test_revertWithInvalidCallTypeMode() public {
         (Execution[] memory executions_, bytes memory terms_) = _setupValidBatchAndTerms();
         bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
 
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-call-type");
         batchEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
+    }
+
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        (Execution[] memory executions_, bytes memory terms_) = _setupValidBatchAndTerms();
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
+
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        batchEnforcer.beforeHook(terms_, hex"", batchTryMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail when trying to reuse a delegation

--- a/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
+++ b/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import { Execution, Caveat, Delegation, ModeCode } from "../../src/utils/Types.sol";
@@ -15,14 +14,10 @@ import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { BasicERC20, IERC20 } from "../utils/BasicERC20.t.sol";
 
 contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////// State //////////////////////
 
     SpecificActionERC20TransferBatchEnforcer public batchEnforcer;
     BasicERC20 public token;
-    ModeCode public batchMode = ModeLib.encodeSimpleBatch();
-    ModeCode public singleMode = ModeLib.encodeSimpleSingle();
     uint256 public constant TRANSFER_AMOUNT = 10 ether;
 
     ////////////////////// Set up //////////////////////
@@ -50,7 +45,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
             delegationHash_,
             delegator_ // delegator
         );
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, delegationHash_, delegator_, address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, delegationHash_, delegator_, address(0));
     }
 
     // should allow multiple different delegations with same parameters
@@ -61,24 +56,28 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
         vm.startPrank(address(delegationManager));
 
         // First delegation
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("delegation1"), address(0), address(0));
+        batchEnforcer.beforeHook(
+            terms_, hex"", batchDefaultMode, executionCallData_, keccak256("delegation1"), address(0), address(0)
+        );
 
         // Second delegation with different hash
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("delegation2"), address(0), address(0));
+        batchEnforcer.beforeHook(
+            terms_, hex"", batchDefaultMode, executionCallData_, keccak256("delegation2"), address(0), address(0)
+        );
 
         vm.stopPrank();
     }
 
     ////////////////////// Invalid cases //////////////////////
 
-    // should fail with invalid mode (single mode instead of batch)
+    // should fail with invalid call type mode (single mode instead of batch)
     function test_revertWithInvalidMode() public {
         (Execution[] memory executions_, bytes memory terms_) = _setupValidBatchAndTerms();
         bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
 
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-call-type");
-        batchEnforcer.beforeHook(terms_, hex"", singleMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail when trying to reuse a delegation
@@ -90,11 +89,11 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
         vm.startPrank(address(delegationManager));
 
         // First use
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, delegationHash_, address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, delegationHash_, address(0), address(0));
 
         // Attempt reuse
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:delegation-already-used");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, delegationHash_, address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, delegationHash_, address(0), address(0));
 
         vm.stopPrank();
     }
@@ -113,7 +112,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-batch-size");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid first transaction target
@@ -124,7 +123,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-first-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid first transaction value
@@ -135,7 +134,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-first-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid first transaction calldata
@@ -146,7 +145,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-first-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction target
@@ -157,7 +156,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction value
@@ -168,7 +167,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction calldata length
@@ -179,7 +178,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction selector
@@ -191,7 +190,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction recipient
@@ -203,7 +202,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid second transaction amount
@@ -215,7 +214,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         vm.prank(address(delegationManager));
         vm.expectRevert("SpecificActionERC20TransferBatchEnforcer:invalid-second-transaction");
-        batchEnforcer.beforeHook(terms_, hex"", batchMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(terms_, hex"", batchDefaultMode, executionCallData_, keccak256("test"), address(0), address(0));
     }
 
     // should fail with invalid terms length
@@ -281,7 +280,7 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
         // Set up batch mode
         ModeCode[] memory oneBatchMode_ = new ModeCode[](1);
-        oneBatchMode_[0] = batchMode;
+        oneBatchMode_[0] = batchDefaultMode;
 
         // Bob redeems the delegation to execute the batch
         vm.prank(users.bob.addr);

--- a/test/enforcers/ValueLteEnforcer.t.sol
+++ b/test/enforcers/ValueLteEnforcer.t.sol
@@ -3,23 +3,19 @@ pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicERC20 } from "../utils/BasicERC20.t.sol";
-import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 
 import "../../src/utils/Types.sol";
-import { Execution, ModeCode } from "../../src/utils/Types.sol";
+import { Execution } from "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { ValueLteEnforcer } from "../../src/enforcers/ValueLteEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 
 contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
-    using ModeLib for ModeCode;
-
     ////////////////////////////// State //////////////////////////////
     ValueLteEnforcer public enforcer;
     BasicERC20 public token;
     address delegator;
-    ModeCode public mode = ModeLib.encodeSimpleSingle();
 
     ////////////////////////////// Events //////////////////////////////
 
@@ -67,7 +63,7 @@ contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Should not revert
-        enforcer.beforeHook(terms_, "", mode, executionCallData_, bytes32(0), address(0), address(0));
+        enforcer.beforeHook(terms_, "", singleDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
 
         // Less than
         execution_ = Execution({
@@ -78,7 +74,7 @@ contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
         executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Should not revert
-        enforcer.beforeHook(terms_, "", mode, executionCallData_, bytes32(0), address(0), address(0));
+        enforcer.beforeHook(terms_, "", singleDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     //////////////////////// Errors ////////////////////////
@@ -96,7 +92,7 @@ contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
 
         // Should not revert
         vm.expectRevert(bytes("ValueLteEnforcer:value-too-high"));
-        enforcer.beforeHook(terms_, "", mode, executionCallData_, bytes32(0), address(0), address(0));
+        enforcer.beforeHook(terms_, "", singleDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
     // Validates the terms are well formed
@@ -114,7 +110,14 @@ contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.getTermsInfo(terms_);
     }
 
-    //////////////////////  Integration  //////////////////////
+    // Should fail with invalid call type mode (batch instead of single mode)
+    function test_revertWithInvalidCallTypeMode() public {
+        bytes memory executionCallData_ = ExecutionLib.encodeBatch(new Execution[](2));
+
+        vm.expectRevert("CaveatEnforcer:invalid-call-type");
+
+        enforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/helpers/DelegationMetaSwapAdapter.t.sol
+++ b/test/helpers/DelegationMetaSwapAdapter.t.sol
@@ -11,7 +11,7 @@ import { BaseTest } from "../utils/BaseTest.t.sol";
 import { DelegationMetaSwapAdapter } from "../../src/helpers/DelegationMetaSwapAdapter.sol";
 import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
 import { Implementation, SignatureType, TestUser } from "../utils/Types.t.sol";
-import { Delegation, Caveat, ModeCode } from "../../src/utils/Types.sol";
+import { Delegation, Caveat } from "../../src/utils/Types.sol";
 import { IDelegationManager } from "../../src/interfaces/IDelegationManager.sol";
 import { IMetaSwap } from "../../src/helpers/interfaces/IMetaSwap.sol";
 import { AllowedTargetsEnforcer } from "../../src/enforcers/AllowedTargetsEnforcer.sol";
@@ -524,8 +524,7 @@ contract DelegationMetaSwapAdapterMockTest is DelegationMetaSwapAdapterBaseTest 
         _setUpMockContracts();
         vm.startPrank(address(subVault.deleGator));
         vm.expectRevert(DelegationMetaSwapAdapter.NotDelegationManager.selector);
-        ModeCode modeCode_;
-        delegationMetaSwapAdapter.executeFromExecutor(modeCode_, hex"");
+        delegationMetaSwapAdapter.executeFromExecutor(singleDefaultMode, hex"");
         vm.stopPrank();
     }
 

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -17,13 +17,14 @@ import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { P256SCLVerifierLib } from "../../src/libraries/P256SCLVerifierLib.sol";
 import { SCL_Wrapper } from "./SCLWrapperLib.sol";
 
+import { CALLTYPE_SINGLE, CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT } from "../../src/utils/Constants.sol";
 import { EXECUTE_SIGNATURE } from "./Constants.sol";
 import { EncoderLib } from "../../src/libraries/EncoderLib.sol";
 import { TestUser, TestUsers, Implementation, SignatureType } from "./Types.t.sol";
 import { SigningUtilsLib } from "./SigningUtilsLib.t.sol";
 import { StorageUtilsLib } from "./StorageUtilsLib.t.sol";
 import { UserOperationLib } from "./UserOperationLib.t.sol";
-import { Execution, PackedUserOperation, Delegation, ModeCode } from "../../src/utils/Types.sol";
+import { Execution, PackedUserOperation, Delegation, ModeCode, ModePayload } from "../../src/utils/Types.sol";
 import { SimpleFactory } from "../../src/utils/SimpleFactory.sol";
 import { DelegationManager } from "../../src/DelegationManager.sol";
 import { DeleGatorCore } from "../../src/DeleGatorCore.sol";
@@ -66,6 +67,12 @@ abstract contract BaseTest is Test {
     // Tracks the user's nonce
     mapping(address entryPoint => mapping(address user => uint256 nonce)) public senderNonce;
     // mapping(address user => uint256 nonce) public senderNonce;
+
+    // Execution modes
+    ModeCode public singleDefaultMode = ModeLib.encodeSimpleSingle();
+    ModeCode public batchDefaultMode = ModeLib.encodeSimpleBatch();
+    ModeCode public singleTryMode = ModeLib.encode(CALLTYPE_SINGLE, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00));
+    ModeCode public batchTryMode = ModeLib.encode(CALLTYPE_BATCH, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00));
 
     ////////////////////////////// Set Up //////////////////////////////
 


### PR DESCRIPTION
### **What?**

- Added new modifiers `onlySingleCallTypeMode, onlyBatchCallTypeMode, onlyDefaultExecutionMode, onlyTryExecutionMode`,  these allow to restrict the enforcer functions by execution mode and callType mode. 
- Modified the tests to use the modes from the baseTest instead of recreating the modes on each test

### **Why?**

- Some enforcers required validation against a try mode that doesn't revert on failures, execution mode modifiers validate that.

### **How?**

- Separate enforcers allow to customize the functions, they can be combined, one callTypeMode and one executionMode
