### PR TITLE
Audit - Feb 2025 - 7.1.1 - Add Entry Point to the UserOp Hash

### DIFF
--- a/src/DeleGatorCore.sol
+++ b/src/DeleGatorCore.sol
@@ -51,7 +51,7 @@ abstract contract DeleGatorCore is
 
     /// @dev The typehash for the PackedUserOperation struct
     bytes32 public constant PACKED_USER_OP_TYPEHASH = keccak256(
-        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)"
+        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,address entryPoint)"
     );
 
     ////////////////////////////// Events //////////////////////////////
@@ -481,7 +481,7 @@ abstract contract DeleGatorCore is
      * Provides the typed data hash for a PackedUserOperation
      * @param _userOp the PackedUserOperation to hash
      */
-    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public pure returns (bytes32) {
+    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public view returns (bytes32) {
         return keccak256(
             abi.encode(
                 PACKED_USER_OP_TYPEHASH,
@@ -492,7 +492,8 @@ abstract contract DeleGatorCore is
                 _userOp.accountGasLimits,
                 _userOp.preVerificationGas,
                 _userOp.gasFees,
-                keccak256(_userOp.paymasterAndData)
+                keccak256(_userOp.paymasterAndData),
+                entryPoint
             )
         );
     }

--- a/src/EIP7702/EIP7702DeleGatorCore.sol
+++ b/src/EIP7702/EIP7702DeleGatorCore.sol
@@ -54,7 +54,7 @@ abstract contract EIP7702DeleGatorCore is
 
     /// @dev The typehash for the PackedUserOperation struct
     bytes32 public constant PACKED_USER_OP_TYPEHASH = keccak256(
-        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)"
+        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,address entryPoint)"
     );
 
     ////////////////////////////// Events //////////////////////////////
@@ -477,7 +477,7 @@ abstract contract EIP7702DeleGatorCore is
      * Provides the typed data hash for a PackedUserOperation
      * @param _userOp the PackedUserOperation to hash
      */
-    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public pure returns (bytes32) {
+    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public view returns (bytes32) {
         return keccak256(
             abi.encode(
                 PACKED_USER_OP_TYPEHASH,
@@ -488,7 +488,8 @@ abstract contract EIP7702DeleGatorCore is
                 _userOp.accountGasLimits,
                 _userOp.preVerificationGas,
                 _userOp.gasFees,
-                keccak256(_userOp.paymasterAndData)
+                keccak256(_userOp.paymasterAndData),
+                entryPoint
             )
         );
     }

--- a/src/HybridDeleGator.sol
+++ b/src/HybridDeleGator.sol
@@ -36,7 +36,7 @@ contract HybridDeleGator is DeleGatorCore, IERC173 {
     string public constant DOMAIN_VERSION = "1";
 
     /// @dev The version of the contract
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.3.0";
 
     /// @dev The storage location used for state
     /// @dev keccak256(abi.encode(uint256(keccak256("DeleGator.HybridDeleGator")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/MultiSigDeleGator.sol
+++ b/src/MultiSigDeleGator.sol
@@ -32,7 +32,7 @@ contract MultiSigDeleGator is DeleGatorCore {
     string public constant DOMAIN_VERSION = "1";
 
     /// @dev The version of the contract
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.3.0";
 
     /// @dev The storage slot for the MultiSig DeleGator
     /// @dev keccak256(abi.encode(uint256(keccak256("DeleGator.MultiSigDeleGator")) - 1)) & ~bytes32(uint256(0xff))

--- a/test/InviteTest.t.sol
+++ b/test/InviteTest.t.sol
@@ -84,7 +84,7 @@ contract InviteTest is BaseTest {
         // Create and Sign UserOp with Bob's key
         PackedUserOperation memory userOp_ =
             createUserOp(predictedAddr_, abi.encodeWithSignature(EXECUTE_SINGULAR_SIGNATURE, execution_), initcode_);
-        userOp_.signature = signHash(users.bob, getPackedUserOperationTypedDataHash(predictedAddr_, userOp_));
+        userOp_.signature = signHash(users.bob, getPackedUserOperationTypedDataHash(predictedAddr_, userOp_, address(entryPoint)));
 
         // Validate the contract hasn't been deployed yet
         assertEq(predictedAddr_.code, hex"");
@@ -190,7 +190,7 @@ contract InviteTest is BaseTest {
 
         PackedUserOperation memory userOp_ = createUserOp(predictedAddr_, userOpCallData_, initcode_);
 
-        userOp_.signature = signHash(users.bob, getPackedUserOperationTypedDataHash(predictedAddr_, userOp_));
+        userOp_.signature = signHash(users.bob, getPackedUserOperationTypedDataHash(predictedAddr_, userOp_, address(entryPoint)));
 
         submitUserOp_Bundler(userOp_);
 
@@ -206,9 +206,17 @@ contract InviteTest is BaseTest {
 
     ////////////////////////////// Helper Methods //////////////////////////////
 
-    function getPackedUserOperationTypedDataHash(address _contract, PackedUserOperation memory userOp_) public returns (bytes32) {
+    function getPackedUserOperationTypedDataHash(
+        address _contract,
+        PackedUserOperation memory userOp_,
+        address _entryPoint
+    )
+        internal
+        view
+        returns (bytes32)
+    {
         return UserOperationLib.getPackedUserOperationTypedDataHash(
-            multiSigDeleGatorImpl.NAME(), multiSigDeleGatorImpl.DOMAIN_VERSION(), block.chainid, _contract, userOp_
+            multiSigDeleGatorImpl.NAME(), multiSigDeleGatorImpl.DOMAIN_VERSION(), block.chainid, _contract, userOp_, _entryPoint
         );
     }
 }

--- a/test/MultiSigDeleGatorTest.t.sol
+++ b/test/MultiSigDeleGatorTest.t.sol
@@ -139,7 +139,12 @@ contract MultiSigDeleGatorTest is BaseTest {
         userOperation_.signature = signHash(
             users.bob,
             UserOperationLib.getPackedUserOperationTypedDataHash(
-                multiSigDeleGatorImpl.NAME(), multiSigDeleGatorImpl.DOMAIN_VERSION(), block.chainid, predictedAddr_, userOperation_
+                multiSigDeleGatorImpl.NAME(),
+                multiSigDeleGatorImpl.DOMAIN_VERSION(),
+                block.chainid,
+                predictedAddr_,
+                userOperation_,
+                address(entryPoint)
             )
         );
 

--- a/test/utils/UserOperationLib.t.sol
+++ b/test/utils/UserOperationLib.t.sol
@@ -9,14 +9,14 @@ import { Eip712Lib } from "./Eip712Lib.t.sol";
 library UserOperationLib {
     /// @dev The typehash for the PackedUserOperation struct
     bytes32 public constant PACKED_USER_OP_TYPEHASH = keccak256(
-        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)"
+        "PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,address entryPoint)"
     );
 
     /**
      * Provides the typed data hash for a PackedUserOperation
      * @param _userOp the PackedUserOperation to hash
      */
-    function getPackedUserOperationHash(PackedUserOperation calldata _userOp) public pure returns (bytes32) {
+    function getPackedUserOperationHash(PackedUserOperation calldata _userOp, address _entryPoint) public pure returns (bytes32) {
         return keccak256(
             abi.encode(
                 PACKED_USER_OP_TYPEHASH,
@@ -27,7 +27,8 @@ library UserOperationLib {
                 _userOp.accountGasLimits,
                 _userOp.preVerificationGas,
                 _userOp.gasFees,
-                keccak256(_userOp.paymasterAndData)
+                keccak256(_userOp.paymasterAndData),
+                _entryPoint
             )
         );
     }
@@ -45,14 +46,16 @@ library UserOperationLib {
         string memory _version,
         uint256 _chainId,
         address _contract,
-        PackedUserOperation calldata _userOp
+        PackedUserOperation calldata _userOp,
+        address _entryPoint
     )
         public
         pure
         returns (bytes32)
     {
         return MessageHashUtils.toTypedDataHash(
-            Eip712Lib.createEip712DomainSeparator(_name, _version, _chainId, _contract), getPackedUserOperationHash(_userOp)
+            Eip712Lib.createEip712DomainSeparator(_name, _version, _chainId, _contract),
+            getPackedUserOperationHash(_userOp, _entryPoint)
         );
     }
 }


### PR DESCRIPTION
### **What?**

- Add entry point address to the userOperation type data hash

### **Why?**

- This change enables protection against replay attacks between entry points.

### **How?**

- Add entry point address to the userOperation type data hash
