### PR TITLE
docs: Fix broken link to EIP-1967

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A simple example is "Alice delegates the ability to use her USDC to Bob limiting
 
 ### DeleGator
 
-A DeleGator is the contract an end user controls and uses to interact with other contracts onchain. A DeleGator is an [EIP-1967](https://eips.ethereum.org/EIPS/eip-1967[EIP1967]) proxy contract that uses a DeleGator Implementation which defines the granular details of how the DeleGator works. Users are free to migrate their DeleGator Implementation as their needs change.
+A DeleGator is the contract an end user controls and uses to interact with other contracts onchain. A DeleGator is an [EIP-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy contract that uses a DeleGator Implementation which defines the granular details of how the DeleGator works. Users are free to migrate their DeleGator Implementation as their needs change.
 
 ### DeleGator Core
 


### PR DESCRIPTION
### **What?**

I’ve updated the broken link to EIP-1967. The previous link was pointing to an invalid URL, and I’ve replaced it with the correct working one.
