### PR TITLE
Added only default mode protection to all enforcers

### DIFF
--- a/src/enforcers/AllowedCalldataEnforcer.sol
+++ b/src/enforcers/AllowedCalldataEnforcer.sol
@@ -9,7 +9,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title AllowedCalldataEnforcer
  * @dev This contract enforces that some subset of the calldata to be executed matches the allowed subset of calldata.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  * @dev A common use case for this enforcer is enforcing function parameters. It's strongly recommended to use this enforcer for
  * validating static types and not dynamic types. Ensuring that dynamic types are correct can be done through a series of
  * AllowedCalldataEnforcer terms but this is tedious and error-prone.
@@ -25,7 +25,7 @@ contract AllowedCalldataEnforcer is CaveatEnforcer {
      * @param _terms This is packed bytes where:
      *   - the first 32 bytes is the start of the subset of calldata bytes
      *   - the remainder of the bytes is the expected value
-     * @param _mode The execution mode for the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The execution the delegate is trying try to execute.
      */
     function beforeHook(
@@ -41,18 +41,9 @@ contract AllowedCalldataEnforcer is CaveatEnforcer {
         pure
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
-        // Ensure that the first two term values are valid and at least 1 byte for value_
-        uint256 dataStart_;
-        bytes memory value_;
-
-        (,, bytes calldata callData_) = _executionCallData.decodeSingle();
-
-        (dataStart_, value_) = getTermsInfo(_terms);
-        uint256 valueLength_ = value_.length;
-        require(dataStart_ + valueLength_ <= callData_.length, "AllowedCalldataEnforcer:invalid-calldata-length");
-
-        require(_compare(callData_[dataStart_:dataStart_ + valueLength_], value_), "AllowedCalldataEnforcer:invalid-calldata");
+        _validateCalldata(_terms, _executionCallData);
     }
 
     /**
@@ -75,5 +66,25 @@ contract AllowedCalldataEnforcer is CaveatEnforcer {
      */
     function _compare(bytes memory _a, bytes memory _b) private pure returns (bool) {
         return keccak256(_a) == keccak256(_b);
+    }
+
+    /**
+     * @notice Validates that the given execution calldata matches the allowed subset specified in terms.
+     * @dev Ensures that a specific portion of the calldata matches the expected value.
+     * @param _terms Encoded terms specifying the expected calldata subset.
+     * @param _executionCallData The calldata of the function execution to be validated.
+     */
+    function _validateCalldata(bytes calldata _terms, bytes calldata _executionCallData) private pure {
+        // Ensure that the first two term values are valid and at least 1 byte for value_
+        uint256 dataStart_;
+        bytes memory value_;
+
+        (,, bytes calldata callData_) = _executionCallData.decodeSingle();
+
+        (dataStart_, value_) = getTermsInfo(_terms);
+        uint256 valueLength_ = value_.length;
+        require(dataStart_ + valueLength_ <= callData_.length, "AllowedCalldataEnforcer:invalid-calldata-length");
+
+        require(_compare(callData_[dataStart_:dataStart_ + valueLength_], value_), "AllowedCalldataEnforcer:invalid-calldata");
     }
 }

--- a/src/enforcers/AllowedMethodsEnforcer.sol
+++ b/src/enforcers/AllowedMethodsEnforcer.sol
@@ -10,7 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title AllowedMethodsEnforcer
  * @dev This contract enforces the allowed methods a delegate may call.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract AllowedMethodsEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -21,7 +21,7 @@ contract AllowedMethodsEnforcer is CaveatEnforcer {
      * @notice Allows the delegator to limit what methods the delegate may call.
      * @dev This function enforces the allowed methods before the transaction is performed.
      * @param _terms A series of 4byte method identifiers, representing the methods that the delegate is allowed to call.
-     * @param _mode The execution mode for the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The execution the delegate is trying try to execute.
      */
     function beforeHook(
@@ -37,21 +37,9 @@ contract AllowedMethodsEnforcer is CaveatEnforcer {
         pure
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
-        (,, bytes calldata callData_) = _executionCallData.decodeSingle();
-
-        require(callData_.length >= 4, "AllowedMethodsEnforcer:invalid-execution-data-length");
-
-        bytes4 targetSig_ = bytes4(callData_[0:4]);
-        bytes4[] memory allowedSignatures_ = getTermsInfo(_terms);
-        uint256 allowedSignaturesLength_ = allowedSignatures_.length;
-
-        for (uint256 i = 0; i < allowedSignaturesLength_; ++i) {
-            if (targetSig_ == allowedSignatures_[i]) {
-                return;
-            }
-        }
-        revert("AllowedMethodsEnforcer:method-not-allowed");
+        _validateMethods(_terms, _executionCallData);
     }
 
     /**
@@ -68,5 +56,30 @@ contract AllowedMethodsEnforcer is CaveatEnforcer {
             allowedMethods_[j] = bytes4(_terms[i:i + 4]);
             j++;
         }
+    }
+
+    /**
+     * @notice Validates that the method being called is within the allowed set.
+     * @dev Extracts the function selector from the execution calldata and checks if it is present
+     *      in the allowed methods specified in `_terms`.
+     * @param _terms Encoded data containing the allowed method selectors (4-byte function identifiers).
+     * @param _executionCallData The calldata of the function execution to be validated.
+     * @dev Reverts if the function selector is not in the allowed list.
+     */
+    function _validateMethods(bytes calldata _terms, bytes calldata _executionCallData) private pure {
+        (,, bytes calldata callData_) = _executionCallData.decodeSingle();
+
+        require(callData_.length >= 4, "AllowedMethodsEnforcer:invalid-execution-data-length");
+
+        bytes4 targetSig_ = bytes4(callData_[0:4]);
+        bytes4[] memory allowedSignatures_ = getTermsInfo(_terms);
+        uint256 allowedSignaturesLength_ = allowedSignatures_.length;
+
+        for (uint256 i = 0; i < allowedSignaturesLength_; ++i) {
+            if (targetSig_ == allowedSignatures_[i]) {
+                return;
+            }
+        }
+        revert("AllowedMethodsEnforcer:method-not-allowed");
     }
 }

--- a/src/enforcers/AllowedTargetsEnforcer.sol
+++ b/src/enforcers/AllowedTargetsEnforcer.sol
@@ -9,7 +9,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title AllowedTargetsEnforcer
  * @dev This contract enforces the allowed target addresses for a delegate.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract AllowedTargetsEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -20,7 +20,7 @@ contract AllowedTargetsEnforcer is CaveatEnforcer {
      * @notice Allows the delegator to limit what addresses the delegate may call.
      * @dev This function enforces the allowed target addresses before the transaction is performed.
      * @param _terms A series of 20byte addresses, representing the addresses that the delegate is allowed to call.
-     * @param _mode The execution mode for the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The execution the delegate is trying try to execute.
      */
     function beforeHook(
@@ -36,6 +36,7 @@ contract AllowedTargetsEnforcer is CaveatEnforcer {
         pure
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         (address target_,,) = _executionCallData.decodeSingle();
 

--- a/src/enforcers/ArgsEqualityCheckEnforcer.sol
+++ b/src/enforcers/ArgsEqualityCheckEnforcer.sol
@@ -12,6 +12,7 @@ import { ModeCode } from "../utils/Types.sol";
  * redemption to a when the result of an onchain computation matches the pre-determined `terms` of a delegation. For example,
  * if the contract sets the args to the users balance of ETH, the delegation will only be valid when that delegation matches
  * the amount set in the `terms`.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract ArgsEqualityCheckEnforcer is CaveatEnforcer {
     ////////////////////////////// Events //////////////////////////////
@@ -25,13 +26,14 @@ contract ArgsEqualityCheckEnforcer is CaveatEnforcer {
      * @notice Enforces that the terms and args are the same
      * @param _terms Any terms that need to be compared against the args
      * @param _args Any args that need to be compared against the terms
+     * @param _mode The execution mode. (Must be Default execType)
      * @param _delegationHash The hash of the delegation
      * @param _redeemer The address of the redeemer
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata _args,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -39,6 +41,7 @@ contract ArgsEqualityCheckEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         if (keccak256(_terms) != keccak256(_args)) {
             emit DifferentArgsAndTerms(msg.sender, _redeemer, _delegationHash, _terms, _args);

--- a/src/enforcers/BlockNumberEnforcer.sol
+++ b/src/enforcers/BlockNumberEnforcer.sol
@@ -7,6 +7,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title BlockNumberEnforcer
  * @dev This contract enforces the block number range for a delegation.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract BlockNumberEnforcer is CaveatEnforcer {
     ////////////////////////////// Public Methods //////////////////////////////
@@ -16,11 +17,12 @@ contract BlockNumberEnforcer is CaveatEnforcer {
      * @dev This function enforces the block number range before the transaction is performed.
      * @param _terms A bytes32 blocknumber range where the first half of the word is the earliest the delegation can be used and
      * the last half of the word is the latest the delegation can be used. The block number ranges are not inclusive.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address,
@@ -29,6 +31,7 @@ contract BlockNumberEnforcer is CaveatEnforcer {
         public
         view
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (uint128 blockAfterThreshold_, uint128 blockBeforeThreshold_) = getTermsInfo(_terms);
 

--- a/src/enforcers/DeployedEnforcer.sol
+++ b/src/enforcers/DeployedEnforcer.sol
@@ -10,6 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title DeployedEnforcer
  * @dev This contract enforces the deployment of a contract if it hasn't been deployed yet.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract DeployedEnforcer is CaveatEnforcer {
     ////////////////////////////// Errors //////////////////////////////
@@ -48,11 +49,12 @@ contract DeployedEnforcer is CaveatEnforcer {
      *    the first 20 bytes are the expected address of the deployed contract
      *    the next 32 bytes are the salt to use for create2
      *    the remaining bytes are the bytecode of the contract to deploy
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address,
@@ -60,6 +62,7 @@ contract DeployedEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (address expectedAddress_, bytes32 salt_, bytes memory bytecode_) = getTermsInfo(_terms);
 

--- a/src/enforcers/ERC1155BalanceGteEnforcer.sol
+++ b/src/enforcers/ERC1155BalanceGteEnforcer.sol
@@ -10,6 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title ERC1155BalanceGteEnforcer
  * @dev This contract enforces that the ERC1155 token balance of a recipient for a specific token ID
  * has increased by at least the specified amount after the execution, measured between the `beforeHook` and `afterHook` calls.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract ERC1155BalanceGteEnforcer is CaveatEnforcer {
     ////////////////////////////// State //////////////////////////////
@@ -51,12 +52,13 @@ contract ERC1155BalanceGteEnforcer is CaveatEnforcer {
      * - next 20 bytes: address of the recipient,
      * - next 32 bytes: token ID,
      * - next 32 bytes: amount the balance should increase by.
+     * @param _mode The execution mode. (Must be Default execType)
      * @param _delegationHash The hash of the delegation.
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -64,6 +66,7 @@ contract ERC1155BalanceGteEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (address token_, address recipient_, uint256 tokenId_,) = getTermsInfo(_terms);
         bytes32 hashKey_ = _getHashKey(msg.sender, token_, recipient_, tokenId_, _delegationHash);

--- a/src/enforcers/ERC20BalanceGteEnforcer.sol
+++ b/src/enforcers/ERC20BalanceGteEnforcer.sol
@@ -13,6 +13,7 @@ import { ModeCode } from "../utils/Types.sol";
  * is.
  * @dev This contract has no enforcement of how the balance increases. It's meant to be used alongside additional enforcers to
  * create granular permissions.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract ERC20BalanceGteEnforcer is CaveatEnforcer {
     ////////////////////////////// State //////////////////////////////
@@ -39,11 +40,12 @@ contract ERC20BalanceGteEnforcer is CaveatEnforcer {
      * @notice This function caches the delegators ERC20 balance before the delegation is executed.
      * @param _terms 72 packed bytes where: the first 20 bytes is the address of the recipient, the next 20 bytes
      * is the address of the token, the next 32 bytes is the amount of tokens the balance should be greater than or equal to
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -51,6 +53,7 @@ contract ERC20BalanceGteEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (address recipient_, address token_,) = getTermsInfo(_terms);
         bytes32 hashKey_ = _getHashKey(msg.sender, token_, _delegationHash);

--- a/src/enforcers/ERC20PeriodTransferEnforcer.sol
+++ b/src/enforcers/ERC20PeriodTransferEnforcer.sol
@@ -13,7 +13,8 @@ import { ModeCode } from "../utils/Types.sol";
  * @dev This contract implements a mechanism by which a user may transfer up to a fixed amount of tokens (the period amount)
  *      during a given time period. The transferable amount resets at the beginning of each period, and any unused tokens
  *      are forfeited once the period ends. Partial transfers within a period are allowed, but the total transfer in any
- *      period cannot exceed the specified limit. This enforcer is designed to work only in single execution mode (ModeCode.Single).
+ *      period cannot exceed the specified limit.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract ERC20PeriodTransferEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -110,7 +111,7 @@ contract ERC20PeriodTransferEnforcer is CaveatEnforcer {
      *  - 32 bytes: periodAmount.
      *  - 32 bytes: periodDuration (in seconds).
      *  - 32 bytes: startDate for the first period.
-     * @param _mode The execution mode (must be ModeCode.Single).
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The transaction data (should be an `IERC20.transfer(address,uint256)` call).
      * @param _delegationHash The hash identifying the delegation.
      * @param _redeemer The address intended to receive the tokens.
@@ -127,6 +128,7 @@ contract ERC20PeriodTransferEnforcer is CaveatEnforcer {
         public
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         _validateAndConsumeTransfer(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/ERC20StreamingEnforcer.sol
+++ b/src/enforcers/ERC20StreamingEnforcer.sol
@@ -19,7 +19,7 @@ import { ModeCode } from "../utils/Types.sol";
  *  5. The enforcer tracks how many tokens have already been spent, and will revert
  *     if an attempted transfer exceeds what remains unlocked.
  *
- * @dev This caveat enforcer only works when the execution is in single mode (`ModeCode.Single`).
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  * @dev To enable an 'infinite' token stream, set `maxAmount` to type(uint256).max
  */
 contract ERC20StreamingEnforcer is CaveatEnforcer {
@@ -85,7 +85,7 @@ contract ERC20StreamingEnforcer is CaveatEnforcer {
      * - 32 bytes: max amount.
      * - 32 bytes: amount per second.
      * - 32 bytes: start time for the streaming allowance.
-     * @param _mode The mode of the execution (must be `ModeCode.Single` for this enforcer).
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The transaction the delegate might try to perform.
      * @param _delegationHash The hash of the delegation being operated on.
      * @param _redeemer The address of the redeemer.
@@ -102,6 +102,7 @@ contract ERC20StreamingEnforcer is CaveatEnforcer {
         public
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         _validateAndConsumeAllowance(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/ERC20TransferAmountEnforcer.sol
+++ b/src/enforcers/ERC20TransferAmountEnforcer.sol
@@ -10,7 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title ERC20TransferAmountEnforcer
  * @dev This contract enforces the transfer limit for ERC20 tokens.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract ERC20TransferAmountEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -31,7 +31,7 @@ contract ERC20TransferAmountEnforcer is CaveatEnforcer {
      * @dev This function enforces the transfer limit before the transaction is performed.
      * @param _terms The ERC20 token address, and the numeric maximum amount that the recipient may transfer on the signer's
      * behalf.
-     * @param _mode The mode of the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The transaction the delegate might try to perform.
      * @param _delegationHash The hash of the delegation being operated on.
      */

--- a/src/enforcers/ERC721BalanceGteEnforcer.sol
+++ b/src/enforcers/ERC721BalanceGteEnforcer.sol
@@ -10,6 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title ERC721BalanceGteEnforcer
  * @dev This contract enforces that the ERC721 token balance of a recipient has increased by at least the specified amount
  * after the execution, measured between the `beforeHook` and `afterHook` calls, regardless of what the execution is.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract ERC721BalanceGteEnforcer is CaveatEnforcer {
     ////////////////////////////// State //////////////////////////////
@@ -48,12 +49,13 @@ contract ERC721BalanceGteEnforcer is CaveatEnforcer {
      * - first 20 bytes: address of the ERC721 token,
      * - next 20 bytes: address of the recipient,
      * - next 32 bytes: amount the balance should increase by.
+     * @param _mode The execution mode. (Must be Default execType)
      * @param _delegationHash The hash of the delegation.
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -61,6 +63,7 @@ contract ERC721BalanceGteEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (address token_, address recipient_,) = getTermsInfo(_terms);
         bytes32 hashKey_ = _getHashKey(msg.sender, token_, recipient_, _delegationHash);

--- a/src/enforcers/ERC721TransferEnforcer.sol
+++ b/src/enforcers/ERC721TransferEnforcer.sol
@@ -9,6 +9,7 @@ import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 /**
  * @title ERC721TransferEnforcer
  * @notice This enforcer restricts the action of a UserOp to the transfer of a specific ERC721 token.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract ERC721TransferEnforcer is CaveatEnforcer {
     bytes4 private constant SAFE_TRANSFER_FROM_SELECTOR_1 = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
@@ -17,7 +18,7 @@ contract ERC721TransferEnforcer is CaveatEnforcer {
     /**
      * @notice Enforces that the contract and tokenId are permitted for transfer
      * @param _terms abi encoded address of the contract and uint256 of the tokenId
-     * @param _mode the execution mode of the transaction
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData the call data of the transferFrom call
      */
     function beforeHook(
@@ -33,6 +34,7 @@ contract ERC721TransferEnforcer is CaveatEnforcer {
         virtual
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         (address permittedContract_, uint256 permittedTokenId_) = getTermsInfo(_terms);
         (address target_,, bytes calldata callData_) = ExecutionLib.decodeSingle(_executionCallData);

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -21,7 +21,7 @@ contract ExactCalldataBatchEnforcer is CaveatEnforcer {
     /**
      * @notice Validates that each execution's calldata in the batch matches the expected calldata.
      * @param _terms The encoded expected Executions.
-     * @param _mode The execution mode, which must be batch.
+     * @param _mode The execution mode. (Must be Batch callType, Default execType)
      * @param _executionCallData The batch execution calldata.
      */
     function beforeHook(

--- a/src/enforcers/ExactCalldataEnforcer.sol
+++ b/src/enforcers/ExactCalldataEnforcer.sol
@@ -9,7 +9,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title ExactCalldataEnforcer
  * @notice Ensures that the provided execution calldata matches exactly the expected calldata.
- * @dev This caveat enforcer operates only in single execution mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract ExactCalldataEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -19,7 +19,7 @@ contract ExactCalldataEnforcer is CaveatEnforcer {
     /**
      * @notice Validates that the execution calldata matches the expected calldata.
      * @param _terms The encoded expected calldata.
-     * @param _mode The execution mode, which must be single.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The calldata provided for execution.
      */
     function beforeHook(
@@ -35,6 +35,7 @@ contract ExactCalldataEnforcer is CaveatEnforcer {
         pure
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         (,, bytes calldata callData_) = _executionCallData.decodeSingle();
 

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -21,7 +21,7 @@ contract ExactExecutionBatchEnforcer is CaveatEnforcer {
     /**
      * @notice Validates that each execution in the batch matches exactly with the expected execution.
      * @param _terms The encoded expected Executions.
-     * @param _mode The execution mode, which must be batch.
+     * @param _mode The execution mode. (Must be Batch callType, Default execType)
      * @param _executionCallData The batch execution calldata.
      */
     function beforeHook(

--- a/src/enforcers/IdEnforcer.sol
+++ b/src/enforcers/IdEnforcer.sol
@@ -11,6 +11,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @dev This contract extends the CaveatEnforcer contract. It provides functionality to enforce id
  * restrictions on delegations. A delegator can assign the same id to multiple delegations, once one of them
  * is redeemed the other delegations with the same id will revert.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract IdEnforcer is CaveatEnforcer {
     using BitMaps for BitMaps.BitMap;
@@ -27,11 +28,12 @@ contract IdEnforcer is CaveatEnforcer {
     /**
      * @notice Allows the delegator to specify a id for the delegation, that id can be redeemed only once.
      * @param _terms A uint256 representing the id used in the delegation.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address _delegator,
@@ -39,6 +41,7 @@ contract IdEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         uint256 id_ = getTermsInfo(_terms);
         require(!getIsUsed(msg.sender, _delegator, id_), "IdEnforcer:id-already-used");

--- a/src/enforcers/LimitedCallsEnforcer.sol
+++ b/src/enforcers/LimitedCallsEnforcer.sol
@@ -8,6 +8,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title Limited Calls Enforcer Contract
  * @dev This contract extends the CaveatEnforcer contract. It provides functionality to enforce a limit on the number of times a
  * delegate may perform transactions on behalf of the delegator.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract LimitedCallsEnforcer is CaveatEnforcer {
     ////////////////////////////// State //////////////////////////////
@@ -26,11 +27,12 @@ contract LimitedCallsEnforcer is CaveatEnforcer {
      * @notice Allows the delegator to specify a maximum number of times the recipient may perform transactions on their behalf.
      * @param _terms - The maximum number of times the delegate may perform transactions on their behalf.
      * @param _delegationHash - The hash of the delegation being operated on.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -38,6 +40,7 @@ contract LimitedCallsEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         uint256 limit_ = getTermsInfo(_terms);
         uint256 callCounts_ = ++callCounts[msg.sender][_delegationHash];

--- a/src/enforcers/NativeBalanceGteEnforcer.sol
+++ b/src/enforcers/NativeBalanceGteEnforcer.sol
@@ -11,6 +11,7 @@ import { ModeCode } from "../utils/Types.sol";
  * is.
  * @dev This contract does not enforce how the balance increases. It is meant to be used with additional enforcers to create
  * granular permissions.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract NativeBalanceGteEnforcer is CaveatEnforcer {
     ////////////////////////////// State //////////////////////////////
@@ -37,11 +38,12 @@ contract NativeBalanceGteEnforcer is CaveatEnforcer {
      * @param _terms 52 packed bytes where the first 20 bytes are the recipient's address, and the next 32 bytes
      * are the minimum balance increase required.
      * @param _delegationHash The hash of the delegation being operated on.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address,
@@ -49,6 +51,7 @@ contract NativeBalanceGteEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         bytes32 hashKey_ = _getHashKey(msg.sender, _delegationHash);
         (address recipient_,) = getTermsInfo(_terms);

--- a/src/enforcers/NativeTokenPaymentEnforcer.sol
+++ b/src/enforcers/NativeTokenPaymentEnforcer.sol
@@ -19,7 +19,7 @@ import { IDelegationManager } from "../interfaces/IDelegationManager.sol";
  * protecting the delegation.
  * @dev It is recommended to combine the allowance delegation with the `NativeTokenTransferAmountEnforcer` to ensure the correct
  * token transfer amount.
- * @dev Requires the redeemer to be a DeleGator that supports the single execution mode.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract NativeTokenPaymentEnforcer is CaveatEnforcer {
     using ModeLib for ModeCode;
@@ -57,6 +57,7 @@ contract NativeTokenPaymentEnforcer is CaveatEnforcer {
      * @param _terms Encoded 52 packed bytes where: the first 20 bytes are the address of the recipient,
      * the next 32 bytes are the amount to charge for the delegation.
      * @param _args Encoded arguments containing the allowance delegation chain for the payment.
+     * @param _mode The execution mode. (Must be Default execType)
      * @param _delegationHash The hash of the delegation.
      * @param _delegator The address of the delegator.
      * @param _redeemer The address that is redeeming the delegation.
@@ -64,7 +65,7 @@ contract NativeTokenPaymentEnforcer is CaveatEnforcer {
     function afterAllHook(
         bytes calldata _terms,
         bytes calldata _args,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32 _delegationHash,
         address _delegator,
@@ -72,6 +73,7 @@ contract NativeTokenPaymentEnforcer is CaveatEnforcer {
     )
         public
         override
+        onlyDefaultExecutionMode(_mode)
     {
         require(msg.sender == address(delegationManager), "NativeTokenPaymentEnforcer:only-delegation-manager");
 

--- a/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
+++ b/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
@@ -12,7 +12,8 @@ import { ModeCode } from "../utils/Types.sol";
  * @dev This contract implements a mechanism by which a user may transfer up to a fixed amount of ETH (the period amount)
  *      during a given time period. The transferable amount resets at the beginning of each period and any unused ETH is
  *      forfeited once the period ends. Partial transfers within a period are allowed, but the total transfer in any period
- *      cannot exceed the specified limit. This enforcer is designed to work only in single execution mode (ModeCode.Single).
+ *      cannot exceed the specified limit.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract NativeTokenPeriodTransferEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -102,7 +103,7 @@ contract NativeTokenPeriodTransferEnforcer is CaveatEnforcer {
      *  - 32 bytes: periodAmount.
      *  - 32 bytes: periodDuration (in seconds).
      *  - 32 bytes: startDate for the first period.
-     * @param _mode The execution mode (must be ModeCode.Single).
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The execution data encoded via ExecutionLib.encodeSingle.
      *        For native ETH transfers, decodeSingle returns (target, value, callData) and callData is expected to be empty.
      * @param _delegationHash The hash identifying the delegation.
@@ -119,6 +120,7 @@ contract NativeTokenPeriodTransferEnforcer is CaveatEnforcer {
         public
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         _validateAndConsumeTransfer(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/NativeTokenStreamingEnforcer.sol
+++ b/src/enforcers/NativeTokenStreamingEnforcer.sol
@@ -17,7 +17,7 @@ import { ModeCode } from "../utils/Types.sol";
  *  5. The contract tracks how many native tokens have been spent and will revert
  *     if an attempted transfer (i.e. the value sent) exceeds what remains unlocked.
  *
- * @dev This enforcer only works when the execution is in single mode (`ModeCode.Single`).
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  * @dev To enable an 'infinite' token stream, set `maxAmount` to type(uint256).max
  */
 contract NativeTokenStreamingEnforcer is CaveatEnforcer {
@@ -80,7 +80,7 @@ contract NativeTokenStreamingEnforcer is CaveatEnforcer {
      * - 32 bytes: max amount.
      * - 32 bytes: amount per second.
      * - 32 bytes: start time for the streaming allowance.
-     * @param _mode The execution mode (must be `ModeCode.Single`).
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The execution data which, when decoded via ExecutionLib.decodeSingle(),
      *        yields (target, value, callData). Here, the `value` is the native token amount.
      * @param _delegationHash The hash of the delegation being operated on.
@@ -98,6 +98,7 @@ contract NativeTokenStreamingEnforcer is CaveatEnforcer {
         public
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         _validateAndConsumeAllowance(_terms, _executionCallData, _delegationHash, _redeemer);
     }

--- a/src/enforcers/NativeTokenTransferAmountEnforcer.sol
+++ b/src/enforcers/NativeTokenTransferAmountEnforcer.sol
@@ -9,6 +9,7 @@ import { ModeCode } from "../utils/Types.sol";
 /**
  * @title NativeTokenTransferAmountEnforcer
  * @notice This contract enforces an allowance of native currency (e.g., ETH) for a specific delegation.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract NativeTokenTransferAmountEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -29,7 +30,7 @@ contract NativeTokenTransferAmountEnforcer is CaveatEnforcer {
     /**
      * @notice Enforces the conditions that should hold before a transaction is performed.
      * @param _terms The encoded amount of native token allowance.
-     * @param _mode The mode of the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The call data of the execution.
      * @param _delegationHash The hash of the delegation.
      */

--- a/src/enforcers/NonceEnforcer.sol
+++ b/src/enforcers/NonceEnforcer.sol
@@ -8,6 +8,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title Nonce Enforcer Contract
  * @dev This contract extends the CaveatEnforcer contract. It provides functionality to add an nonce to a delegation and enable
  * multi delegation revocation based on that nonce by incrementing the current nonce.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract NonceEnforcer is CaveatEnforcer {
     ////////////////////// State //////////////////////
@@ -23,11 +24,12 @@ contract NonceEnforcer is CaveatEnforcer {
     /**
      * @notice
      * @param _terms A uint256 representing the nonce used in the delegation.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address _delegator,
@@ -36,6 +38,7 @@ contract NonceEnforcer is CaveatEnforcer {
         public
         view
         override
+        onlyDefaultExecutionMode(_mode)
     {
         uint256 nonce_ = getTermsInfo(_terms);
         require(currentNonce[msg.sender][_delegator] == nonce_, "NonceEnforcer:invalid-nonce");

--- a/src/enforcers/OwnershipTransferEnforcer.sol
+++ b/src/enforcers/OwnershipTransferEnforcer.sol
@@ -10,7 +10,7 @@ import { IERC173 } from "../interfaces/IERC173.sol";
 /**
  * @title OwnershipTransferEnforcer
  * @dev This contract enforces the ownership transfer of ERC-173 compliant contracts.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract OwnershipTransferEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -26,7 +26,7 @@ contract OwnershipTransferEnforcer is CaveatEnforcer {
      * @notice Enforces the ownership transfer of an ERC-173 compliant contract.
      * @dev This function enforces the ownership transfer before the transaction is performed.
      * @param _terms The address of the contract whose ownership is being transferred.
-     * @param _mode The mode of the execution.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      * @param _executionCallData The transaction the delegate might try to perform.
      * @param _delegationHash The hash of the delegation being operated on.
      */
@@ -42,6 +42,7 @@ contract OwnershipTransferEnforcer is CaveatEnforcer {
         public
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         address newOwner = _validateAndEnforce(_terms, _executionCallData);
         emit OwnershipTransferEnforced(msg.sender, _redeemer, _delegationHash, newOwner);

--- a/src/enforcers/RedeemerEnforcer.sol
+++ b/src/enforcers/RedeemerEnforcer.sol
@@ -8,7 +8,8 @@ import { ModeCode } from "../utils/Types.sol";
  * @title RedeemerEnforcer
  * @dev This contract restricts the addresses that can redeem delegations.
  * Specifically designed for smart contracts or EOAs lacking delegation support.
- * Note: DeleGator accounts with delegation functionalities may bypass these restrictions by delegating to other addresses.
+ * @dev DeleGator accounts with delegation functionalities may bypass these restrictions by delegating to other addresses.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract RedeemerEnforcer is CaveatEnforcer {
     ////////////////////////////// Public Methods //////////////////////////////
@@ -16,12 +17,13 @@ contract RedeemerEnforcer is CaveatEnforcer {
     /**
      * @notice Allows the delegator to limit which addresses can redeem the delegation.
      * @param _terms Encoded 20-byte addresses of the allowed redeemers.
+     * @param _mode The execution mode. (Must be Default execType)
      * @param _redeemer The address attempting to redeem the delegation.
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address,
@@ -30,6 +32,7 @@ contract RedeemerEnforcer is CaveatEnforcer {
         public
         pure
         override
+        onlyDefaultExecutionMode(_mode)
     {
         address[] memory allowedRedeemers_ = getTermsInfo(_terms);
         uint256 allowedRedeemersLength_ = allowedRedeemers_.length;

--- a/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
+++ b/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
@@ -49,7 +49,7 @@ contract SpecificActionERC20TransferBatchEnforcer is CaveatEnforcer {
      *   - Transfer amount (32 bytes)
      *   - First transaction target address (20 bytes)
      *   - First transaction calldata (remaining bytes)
-     * @param _mode The execution mode
+     * @param _mode The execution mode. (Must be Batch callType, Default execType)
      * @param _executionCallData The batch execution calldata
      * @param _delegationHash The delegation hash
      */

--- a/src/enforcers/TimestampEnforcer.sol
+++ b/src/enforcers/TimestampEnforcer.sol
@@ -8,6 +8,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title Timestamp Enforcer Contract
  * @dev This contract extends the CaveatEnforcer contract. It provides functionality to enforce timestamp restrictions on
  * delegations.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract TimestampEnforcer is CaveatEnforcer {
     ////////////////////////////// Public Methods //////////////////////////////
@@ -16,11 +17,12 @@ contract TimestampEnforcer is CaveatEnforcer {
      * @notice Allows the delegator to specify the timestamp range within which the delegation will be valid.
      * @param _terms - A bytes32 timestamp range where the first half of the word is the earliest the delegation can be used and the
      * last half of the word is the latest the delegation can be used. The timestamp ranges are not inclusive.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address,
@@ -29,6 +31,7 @@ contract TimestampEnforcer is CaveatEnforcer {
         public
         view
         override
+        onlyDefaultExecutionMode(_mode)
     {
         (uint128 timestampAfterThreshold_, uint128 timestampBeforeThreshold_) = getTermsInfo(_terms);
 

--- a/src/enforcers/ValueLteEnforcer.sol
+++ b/src/enforcers/ValueLteEnforcer.sol
@@ -10,7 +10,7 @@ import { ModeCode } from "../utils/Types.sol";
  * @title ValueLteEnforcer
  * @dev This contract extends the CaveatEnforcer contract. It provides functionality to enforce a specific value for the Execution
  * being executed.
- * @dev This caveat enforcer only works when the execution is in single mode.
+ * @dev This enforcer operates only in single execution call type and with default execution mode.
  */
 contract ValueLteEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -20,6 +20,7 @@ contract ValueLteEnforcer is CaveatEnforcer {
     /**
      * @notice Allows the delegator to specify a maximum value of native tokens that the delegate can spend.
      * @param _terms - A uint256 value that the Execution's value must be less than or equal to.
+     * @param _mode The execution mode. (Must be Single callType, Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
@@ -34,6 +35,7 @@ contract ValueLteEnforcer is CaveatEnforcer {
         pure
         override
         onlySingleCallTypeMode(_mode)
+        onlyDefaultExecutionMode(_mode)
     {
         (, uint256 value_,) = _executionCallData.decodeSingle();
         uint256 termsValue_ = getTermsInfo(_terms);

--- a/test/enforcers/AllowedCalldataEnforcer.t.sol
+++ b/test/enforcers/AllowedCalldataEnforcer.t.sol
@@ -217,6 +217,13 @@ contract AllowedCalldataEnforcerTest is CaveatEnforcerBaseTest {
         allowedCalldataEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        allowedCalldataEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should allow a single method to be called when a single function parameter is equal Integration

--- a/test/enforcers/AllowedMethodsEnforcer.t.sol
+++ b/test/enforcers/AllowedMethodsEnforcer.t.sol
@@ -141,6 +141,13 @@ contract AllowedMethodsEnforcerTest is CaveatEnforcerBaseTest {
         allowedMethodsEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        allowedMethodsEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should allow a method to be called when a single method is allowed Integration

--- a/test/enforcers/AllowedTargetsEnforcer.t.sol
+++ b/test/enforcers/AllowedTargetsEnforcer.t.sol
@@ -123,6 +123,13 @@ contract AllowedTargetsEnforcerTest is CaveatEnforcerBaseTest {
         allowedTargetsEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        allowedTargetsEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should allow a method to be called when a multiple targets are allowed Integration

--- a/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
+++ b/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
@@ -46,6 +46,13 @@ contract ArgsEqualityCheckEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        argsEqualityCheckEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(argsEqualityCheckEnforcer));
     }

--- a/test/enforcers/BlockNumberEnforcer.t.sol
+++ b/test/enforcers/BlockNumberEnforcer.t.sol
@@ -181,6 +181,13 @@ contract BlockNumberEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        blockNumberEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should SUCCEED to INVOKE until reaching blockNumber

--- a/test/enforcers/DeployedEnforcer.t.sol
+++ b/test/enforcers/DeployedEnforcer.t.sol
@@ -249,6 +249,13 @@ contract DeployedEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        deployedEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should deploy if the contract hasn't been deployed yet and terms are properly formatted, and allows to use it

--- a/test/enforcers/ERC1155BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC1155BalanceGteEnforcer.t.sol
@@ -256,7 +256,12 @@ contract ERC1155BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
-    //////////////////////  Integration  //////////////////////
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/ERC20BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC20BalanceGteEnforcer.t.sol
@@ -191,7 +191,12 @@ contract ERC20BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), delegator, delegate);
     }
 
-    //////////////////////  Integration  //////////////////////
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/ERC20PeriodTransferEnforcer.t.sol
+++ b/test/enforcers/ERC20PeriodTransferEnforcer.t.sol
@@ -226,6 +226,13 @@ contract ERC20PeriodTransferEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        erc20PeriodTransferEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration Tests //////////////////////
 
     /// @notice Integration: Successfully transfer tokens within the allowance and update state.

--- a/test/enforcers/ERC20StreamingEnforcer.t.sol
+++ b/test/enforcers/ERC20StreamingEnforcer.t.sol
@@ -381,6 +381,13 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
         erc20StreamingEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        erc20StreamingEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     /**

--- a/test/enforcers/ERC20TransferAmountEnforcer.t.sol
+++ b/test/enforcers/ERC20TransferAmountEnforcer.t.sol
@@ -327,10 +327,10 @@ contract ERC20TransferAmountEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
-    // should fail with invalid execution type mode (try instead of default mode)
-    function test_revertWithInvalidExecutionTypeMode() public {
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-execution-type");
-
         erc20TransferAmountEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
     }
 

--- a/test/enforcers/ERC721BalanceGteEnforcer.t.sol
+++ b/test/enforcers/ERC721BalanceGteEnforcer.t.sol
@@ -248,7 +248,12 @@ contract ERC721BalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.afterHook(terms_, hex"", singleDefaultMode, mintExecutionCallData, bytes32(0), address(0), delegate);
     }
 
-    //////////////////////  Integration  //////////////////////
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/ERC721TransferEnforcer.t.sol
+++ b/test/enforcers/ERC721TransferEnforcer.t.sol
@@ -202,6 +202,13 @@ contract ERC721TransferEnforcerTest is CaveatEnforcerBaseTest {
         erc721TransferEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        erc721TransferEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     /// @notice Integration test for valid transfer using transferFrom selector.

--- a/test/enforcers/ExactCalldataEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataEnforcer.t.sol
@@ -153,6 +153,13 @@ contract ExactCalldataEnforcerTest is CaveatEnforcerBaseTest {
         exactCalldataEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        exactCalldataEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////////////// Integration Tests //////////////////////////////
 
     /// @notice Integration test: the enforcer allows a token transfer delegation when calldata matches exactly.

--- a/test/enforcers/ExactExecutionEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionEnforcer.t.sol
@@ -133,6 +133,13 @@ contract ExactExecutionEnforcerTest is CaveatEnforcerBaseTest {
         exactExecutionEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        exactExecutionEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////////////// Integration Tests //////////////////////////////
 
     /// @notice Integration test: the enforcer allows a token transfer when execution matches exactly.

--- a/test/enforcers/IdEnforcer.t.sol
+++ b/test/enforcers/IdEnforcer.t.sol
@@ -78,6 +78,13 @@ contract IdEnforcerEnforcerTest is CaveatEnforcerBaseTest {
         idEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), address(0), redeemer);
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        idEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     //////////////////////  Integration  //////////////////////
 
     // Should revert to use a delegation which nonce has already been used

--- a/test/enforcers/LimitedCallsEnforcer.t.sol
+++ b/test/enforcers/LimitedCallsEnforcer.t.sol
@@ -120,6 +120,13 @@ contract LimitedCallsEnforcerTest is CaveatEnforcerBaseTest {
         limitedCallsEnforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        limitedCallsEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration //////////////////////
 
     // should FAIL to increment counter ABOVE limit number Integration

--- a/test/enforcers/NativeBalanceGteEnforcer.t.sol
+++ b/test/enforcers/NativeBalanceGteEnforcer.t.sol
@@ -130,11 +130,16 @@ contract NativeBalanceGteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _increaseBalance(address _recipient, uint256 _amount) internal {
         vm.deal(_recipient, _recipient.balance + _amount);
     }
-
-    //////////////////////  Integration  //////////////////////
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/NativeTokenPaymentEnforcer.t.sol
+++ b/test/enforcers/NativeTokenPaymentEnforcer.t.sol
@@ -630,6 +630,13 @@ contract NativeTokenPaymentEnforcerTest is CaveatEnforcerBaseTest {
         assertEq(address(users.alice.deleGator).balance, aliceBalanceBefore_ + 1 ether);
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        nativeTokenPaymentEnforcer.afterAllHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getExampleDelegation(
         bytes memory inputTerms_,
         bytes memory args_

--- a/test/enforcers/NativeTokenPeriodTransferEnforcer.t.sol
+++ b/test/enforcers/NativeTokenPeriodTransferEnforcer.t.sol
@@ -175,6 +175,13 @@ contract NativeTokenPeriodTransferEnforcerTest is CaveatEnforcerBaseTest {
         nativeEnforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        nativeEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     ////////////////////// Integration Tests //////////////////////
 
     /// @notice Integration: Simulates a full native ETH transfer via delegation and verifies allowance update.

--- a/test/enforcers/NativeTokenStreamingEnforcer.t.sol
+++ b/test/enforcers/NativeTokenStreamingEnforcer.t.sol
@@ -114,6 +114,13 @@ contract NativeTokenStreamingEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        nativeTokenStreamingEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     //////////////////// Valid cases //////////////////////
 
     /**

--- a/test/enforcers/NativeTokenTransferAmountEnforcer.t.sol
+++ b/test/enforcers/NativeTokenTransferAmountEnforcer.t.sol
@@ -134,10 +134,10 @@ contract NativeTokenTransferAmountEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
-    // should fail with invalid execution type mode (try instead of default mode)
-    function test_revertWithInvalidExecutionTypeMode() public {
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-execution-type");
-
         nativeTokenTransferAmountEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
     }
 

--- a/test/enforcers/NonceEnforcer.t.sol
+++ b/test/enforcers/NonceEnforcer.t.sol
@@ -110,7 +110,12 @@ contract NonceEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, address(0));
     }
 
-    //////////////////////  Integration  //////////////////////
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));

--- a/test/enforcers/OwnershipTransferEnforcer.t.sol
+++ b/test/enforcers/OwnershipTransferEnforcer.t.sol
@@ -131,6 +131,13 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));
     }

--- a/test/enforcers/PasswordEnforcer.t.sol
+++ b/test/enforcers/PasswordEnforcer.t.sol
@@ -59,6 +59,13 @@ contract PasswordEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        passwordEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     //////////////////////  Integration  //////////////////////
 
     function test_userInputIncorrectArgsWithOffchainDelegation() public {

--- a/test/enforcers/RedeemerEnforcer.t.sol
+++ b/test/enforcers/RedeemerEnforcer.t.sol
@@ -109,6 +109,13 @@ contract RedeemerEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        redeemerEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(redeemerEnforcer));
     }

--- a/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
+++ b/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
@@ -82,12 +82,9 @@ contract SpecificActionERC20TransferBatchEnforcerTest is CaveatEnforcerBaseTest 
 
     // should fail with invalid call type mode (try instead of default)
     function test_revertWithInvalidExecutionMode() public {
-        (Execution[] memory executions_, bytes memory terms_) = _setupValidBatchAndTerms();
-        bytes memory executionCallData_ = ExecutionLib.encodeBatch(executions_);
-
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-execution-type");
-        batchEnforcer.beforeHook(terms_, hex"", batchTryMode, executionCallData_, keccak256("test"), address(0), address(0));
+        batchEnforcer.beforeHook(hex"", hex"", batchTryMode, hex"", bytes32(0), address(0), address(0));
     }
 
     // should fail when trying to reuse a delegation

--- a/test/enforcers/TimestampEnforcer.t.sol
+++ b/test/enforcers/TimestampEnforcer.t.sol
@@ -235,6 +235,13 @@ contract TimestampEnforcerTest is CaveatEnforcerBaseTest {
         assertEq(finalValue_, initialValue_ + 1);
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        timestampEnforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(timestampEnforcer));
     }

--- a/test/enforcers/ValueLteEnforcer.t.sol
+++ b/test/enforcers/ValueLteEnforcer.t.sol
@@ -119,6 +119,13 @@ contract ValueLteEnforcerTest is CaveatEnforcerBaseTest {
         enforcer.beforeHook(hex"", hex"", batchDefaultMode, executionCallData_, bytes32(0), address(0), address(0));
     }
 
+    // should fail with invalid call type mode (try instead of default)
+    function test_revertWithInvalidExecutionMode() public {
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        enforcer.beforeHook(hex"", hex"", singleTryMode, hex"", bytes32(0), address(0), address(0));
+    }
+
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {
         return ICaveatEnforcer(address(enforcer));
     }

--- a/test/utils/PasswordCaveatEnforcer.t.sol
+++ b/test/utils/PasswordCaveatEnforcer.t.sol
@@ -7,6 +7,7 @@ import { Execution, ModeCode } from "../../src/utils/Types.sol";
 /**
  * @title Password Enforcer
  * @dev This contract is used only to test the caveat args that are passed in by the redeemer.
+ * @dev This enforcer operates only in default execution mode.
  */
 contract PasswordEnforcer is CaveatEnforcer {
     ////////////////////////////// Public Methods //////////////////////////////
@@ -14,11 +15,12 @@ contract PasswordEnforcer is CaveatEnforcer {
     /**
      * @notice Testing user inputed args.
      * @param _terms A bytes32 that will be hashed.
+     * @param _mode The execution mode. (Must be Default execType)
      */
     function beforeHook(
         bytes calldata _terms,
         bytes calldata _args,
-        ModeCode,
+        ModeCode _mode,
         bytes calldata,
         bytes32,
         address,
@@ -27,6 +29,7 @@ contract PasswordEnforcer is CaveatEnforcer {
         public
         pure
         override
+        onlyDefaultExecutionMode(_mode)
     {
         bytes32 hash_ = keccak256(_args);
         if (hash_ != keccak256(_terms)) revert("PasswordEnforcerError");


### PR DESCRIPTION
### **What?**

- Protection was added so all enforcers must be in default mode. 

### **Why?**

- Enforcers could store state on failed transactions that don't revert when using the try mode.

### **How?**

- Using the modifier `onlyDefaultExecutionMode`
- Some functions failed with stack too deep error, this due to the maximum variables in memory, so I separated their logic to a new function to separate the context
