### PR TITLE
Enable Solidity Optimization With Default Runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,7 @@ solc = "0.8.23"
 fs_permissions = [{ access = "read", path = "./out"},{ access = "read", path = "./broadcast"}, { access = "read-write", path = "./deployments"}]
 sparse_mode = true
 evm_version = "london"
+optimizer = true
 
 [fmt]
   bracket_spacing = true


### PR DESCRIPTION
### **What?**

- Enabling the optimization in the foundry.toml so the deployment scripts and the entire repository uses it

### **Why?**

- Without it we could get some errors with contract size

### **How?**

- Flag in the foundry toml
