### PR TITLE
Audit March 2025 - 7.2.1 - Updated ERC7579 Version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,3 @@
 [submodule "lib/erc7579-implementation"]
 	path = lib/erc7579-implementation
 	url = https://github.com/erc7579/erc7579-implementation
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,12 +13,13 @@
 [submodule "lib/account-abstraction"]
 	path = lib/account-abstraction
 	url = https://github.com/eth-infinitism/account-abstraction
-[submodule "lib/erc7579-implementation"]
-	path = lib/erc7579-implementation
-	url = https://github.com/erc7579/erc7579-implementation
 [submodule "lib/SCL"]
 	path = lib/SCL
 	url = https://github.com/get-smooth/crypto-lib
 [submodule "lib/FCL"]
 	path = lib/FCL
 	url = https://github.com/rdubois-crypto/FreshCryptoLib
+[submodule "lib/erc7579-implementation"]
+	path = lib/erc7579-implementation
+	url = https://github.com/erc7579/erc7579-implementation
+	branch = main


### PR DESCRIPTION
### **What?**

- Updated the version of the erc7579 library that we imported as an external lib.

### **Why?**

- The old version had a bug in one of the events

### **How**
- Static commit version: `16138d1`


<img width="506" alt="image" src="https://github.com/user-attachments/assets/c9806926-a66d-41b0-86ce-2848fc91a935" />
