### PR TITLE
feat: implement NativeTokenMaxLossEnforcer

### DIFF
--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -26,6 +26,7 @@ import { ExactExecutionEnforcer } from "../src/enforcers/ExactExecutionEnforcer.
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
 import { NativeBalanceGteEnforcer } from "../src/enforcers/NativeBalanceGteEnforcer.sol";
+import { NativeTokenMaxLossEnforcer } from "../src/enforcers/NativeTokenMaxLossEnforcer.sol";
 import { NativeTokenPaymentEnforcer } from "../src/enforcers/NativeTokenPaymentEnforcer.sol";
 import { NativeTokenPeriodTransferEnforcer } from "../src/enforcers/NativeTokenPeriodTransferEnforcer.sol";
 import { NativeTokenStreamingEnforcer } from "../src/enforcers/NativeTokenStreamingEnforcer.sol";
@@ -123,6 +124,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new NativeBalanceGteEnforcer{ salt: salt }());
         console2.log("NativeBalanceGteEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new NativeTokenMaxLossEnforcer{ salt: salt }());
+        console2.log("NativeTokenMaxLossEnforcer: %s", deployedAddress);
 
         address argsEqualityCheckEnforcer = address(new ArgsEqualityCheckEnforcer{ salt: salt }());
         console2.log("ArgsEqualityCheckEnforcer: %s", argsEqualityCheckEnforcer);

--- a/src/enforcers/NativeTokenMaxLossEnforcer.sol
+++ b/src/enforcers/NativeTokenMaxLossEnforcer.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode } from "../utils/Types.sol";
+
+/**
+ * @title NativeTokenMaxLossEnforcer
+ * @dev This contract enforces that a recipient's native token balance has decreased by at most the specified amount
+ * after the execution has been executed, measured between the `beforeHook` and `afterHook` calls, regardless of what the execution
+ * is.
+ * @dev This contract does not enforce how the balance decreases. It is meant to be used with additional enforcers to create
+ * granular permissions.
+ */
+contract NativeTokenMaxLossEnforcer is CaveatEnforcer {
+    ////////////////////////////// State //////////////////////////////
+
+    mapping(bytes32 hashKey => uint256 balance) public balanceCache;
+    mapping(bytes32 hashKey => bool lock) public isLocked;
+
+    ////////////////////////////// External Methods //////////////////////////////
+
+    /**
+     * @notice Generates the key that identifies the run, produced by hashing the provided values.
+     * @param _caller Address of the sender calling the enforcer.
+     * @param _delegationHash The hash of the delegation.
+     * @return The hash to be used as key of the mapping.
+     */
+    function getHashKey(address _caller, bytes32 _delegationHash) external pure returns (bytes32) {
+        return _getHashKey(_caller, _delegationHash);
+    }
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Caches the recipient's native token balance before the delegation is executed.
+     * @param _terms 52 packed bytes where the first 20 bytes are the recipient's address, and the next 32 bytes
+     * are the maximum balance decrease.
+     * @param _delegationHash The hash of the delegation being operated on.
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode,
+        bytes calldata,
+        bytes32 _delegationHash,
+        address,
+        address
+    )
+        public
+        override
+    {
+        bytes32 hashKey_ = _getHashKey(msg.sender, _delegationHash);
+        (address recipient_,) = getTermsInfo(_terms);
+
+        require(!isLocked[hashKey_], "NativeTokenMaxLossEnforcer:enforcer-is-locked");
+        isLocked[hashKey_] = true;
+        balanceCache[hashKey_] = recipient_.balance;
+    }
+
+    /**
+     * @notice Ensures that the recipient's native token balance has decreases by at most the specified amount.
+     * @param _terms 52 packed bytes where the first 20 bytes are the recipient's address, and the next 32 bytes
+     * are the maximum balance decrease.
+     * @param _delegationHash The hash of the delegation being operated on.
+     */
+    function afterHook(
+        bytes calldata _terms,
+        bytes calldata,
+        ModeCode,
+        bytes calldata,
+        bytes32 _delegationHash,
+        address,
+        address
+    )
+        public
+        override
+    {
+        (address recipient_, uint256 amount_) = getTermsInfo(_terms);
+        bytes32 hashKey_ = _getHashKey(msg.sender, _delegationHash);
+        delete isLocked[hashKey_];
+        require(recipient_.balance >= balanceCache[hashKey_] - amount_, "NativeTokenMaxLossEnforcer:balance-not-gt");
+    }
+
+    /**
+     * @notice Decodes the terms used in this CaveatEnforcer.
+     * @param _terms 52 packed bytes where the first 20 bytes are the recipient's address, and the next 32 bytes
+     * specify the maximum balance decrease.
+     * @return recipient_ The address of the recipient who will receive the tokens.
+     * @return amount_ maxDecrease_ The maximum balance decrease.
+     */
+    function getTermsInfo(bytes calldata _terms) public pure returns (address recipient_, uint256 amount_) {
+        require(_terms.length == 52, "NativeTokenMaxLossEnforcer:invalid-terms-length");
+        recipient_ = address(bytes20(_terms[:20]));
+        amount_ = uint256(bytes32(_terms[20:]));
+    }
+
+    ////////////////////////////// Internal Methods //////////////////////////////
+
+    /**
+     * @notice Generates the key that identifies the run, produced by hashing the provided values.
+     */
+    function _getHashKey(address _caller, bytes32 _delegationHash) private pure returns (bytes32) {
+        return keccak256(abi.encode(_caller, _delegationHash));
+    }
+}

--- a/test/enforcers/NativeTokenMaxLossEnforcer.t.sol
+++ b/test/enforcers/NativeTokenMaxLossEnforcer.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import "../../src/utils/Types.sol";
+import { Execution } from "../../src/utils/Types.sol";
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { NativeTokenMaxLossEnforcer } from "../../src/enforcers/NativeTokenMaxLossEnforcer.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+import { Counter } from "../utils/Counter.t.sol";
+
+contract NativeTokenMaxLossEnforcerTest is CaveatEnforcerBaseTest {
+    ////////////////////////////// State //////////////////////////////
+    NativeTokenMaxLossEnforcer public enforcer;
+    address delegator;
+    address delegate;
+    address dm;
+    Execution noExecution;
+    bytes executionCallData = abi.encode(noExecution);
+
+    ////////////////////// Set up //////////////////////
+
+    function setUp() public override {
+        super.setUp();
+        delegator = address(users.alice.deleGator);
+        delegate = address(users.bob.deleGator);
+        dm = address(delegationManager);
+        enforcer = new NativeTokenMaxLossEnforcer();
+        vm.label(address(enforcer), "NativeBalanceLte Enforcer");
+        noExecution = Execution(address(0), 0, hex"");
+    }
+
+    ////////////////////// Basic Functionality //////////////////////
+
+    // Validates the terms get decoded correctly
+    function test_decodedTheTerms() public {
+        bytes memory terms_ = abi.encodePacked(address(users.carol.deleGator), uint256(100));
+        uint256 amount_;
+        address recipient_;
+        (recipient_, amount_) = enforcer.getTermsInfo(terms_);
+        assertEq(recipient_, address(address(users.carol.deleGator)));
+        assertEq(amount_, 100);
+    }
+
+    // Validates that a balance has descreased by at most the expected amount
+    function test_allow_ifBalanceDescreases() public {
+        address recipient_ = delegator;
+        // Expect it to decreasee by at most 100
+        bytes memory terms_ = abi.encodePacked(recipient_, uint256(100));
+
+        // Decrease by 100
+        vm.startPrank(dm);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+        _decreaseBalance(delegator, 100);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+
+        // Decrease by 10
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+        _decreaseBalance(delegator, 10);
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+    }
+
+    // ////////////////////// Errors //////////////////////
+
+    // Reverts if a balance changes by more than the specified amount
+    function test_notAllow_exceedsDecrease() public {
+        address recipient_ = delegator;
+        // Expect it to decrease by at most 100
+        bytes memory terms_ = abi.encodePacked(recipient_, uint256(100));
+
+        // Decrease by 101, expect revert
+        vm.startPrank(dm);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+        _decreaseBalance(delegator, 101);
+        vm.expectRevert(bytes("NativeTokenMaxLossEnforcer:balance-not-gt"));
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+    }
+
+    // Reverts if a enforcer is locked
+    function test_notAllow_reenterALockedEnforcer() public {
+        address recipient_ = delegator;
+        // Expect it to decrease by at most 100
+        bytes memory terms_ = abi.encodePacked(recipient_, uint256(100));
+        bytes32 delegationHash_ = bytes32(uint256(99999999));
+
+        vm.startPrank(dm);
+        // Locks the enforcer
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
+        bytes32 hashKey_ = enforcer.getHashKey(address(delegationManager), delegationHash_);
+        assertTrue(enforcer.isLocked(hashKey_));
+        vm.expectRevert(bytes("NativeTokenMaxLossEnforcer:enforcer-is-locked"));
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
+        _decreaseBalance(delegator, 10);
+        vm.startPrank(dm);
+
+        // Unlocks the enforcer
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
+        assertFalse(enforcer.isLocked(hashKey_));
+        // Can be used again, and locks it again
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, delegationHash_, delegator, delegate);
+        assertTrue(enforcer.isLocked(hashKey_));
+    }
+
+    // Validates the terms are well formed
+    function test_invalid_decodedTheTerms() public {
+        address recipient_ = delegator;
+        bytes memory terms_;
+
+        // Too small
+        terms_ = abi.encodePacked(recipient_, uint8(100));
+        vm.expectRevert(bytes("NativeTokenMaxLossEnforcer:invalid-terms-length"));
+        enforcer.getTermsInfo(terms_);
+
+        // Too large
+        terms_ = abi.encodePacked(uint256(100), uint256(100));
+        vm.expectRevert(bytes("NativeTokenMaxLossEnforcer:invalid-terms-length"));
+        enforcer.getTermsInfo(terms_);
+    }
+
+    // Validates that an invalid ID reverts
+    function test_notAllow_expectingOverflow() public {
+        address recipient_ = delegator;
+
+        // Expect balance to increase so much that the validation overflows
+        bytes memory terms_ = abi.encodePacked(recipient_, type(uint256).max);
+        vm.deal(recipient_, type(uint256).min);
+        vm.startPrank(dm);
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+        vm.expectRevert();
+        enforcer.afterHook(terms_, hex"", singleDefaultMode, executionCallData, bytes32(0), delegator, delegate);
+    }
+
+    function _decreaseBalance(address _recipient, uint256 _amount) internal {
+        vm.deal(_recipient, _recipient.balance - _amount);
+    }
+
+    //////////////////////  Integration  //////////////////////
+
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(enforcer));
+    }
+}


### PR DESCRIPTION
### **What?**

- Implement a `NativeTokenMaxLossEnforcer` caveat enforcer, which enforces that your native token balance losses do not exceed a max value

### **Why?**

- A good example of this is when we want to enforce a simulation outcome but, more generally, it could be used to prevent certain types of attacks (e.g. red-pill attacks), by capping our max spending.

### **How?**

- This enforcer was based off of the `NativeBalanceGteEnforcer`, and the logic and tests were just adapted since we're now capping the losses, rather than guaranteeing a minimum gain.

### **Notes**

As a side note, I had proposed to the team that we also rename our current `*BalanceGteEnforcer` caveat enforcers to `*MinGainEnforcer`, since that naming more accurately describes what it enforces IMO.
