### PR TITLE
Add Logical Or Wrapper Enforcer

### DIFF
--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -24,6 +24,7 @@ import { ExactExecutionBatchEnforcer } from "../src/enforcers/ExactExecutionBatc
 import { ExactExecutionEnforcer } from "../src/enforcers/ExactExecutionEnforcer.sol";
 import { IdEnforcer } from "../src/enforcers/IdEnforcer.sol";
 import { LimitedCallsEnforcer } from "../src/enforcers/LimitedCallsEnforcer.sol";
+import { LogicalOrWrapperEnforcer } from "../src/enforcers/LogicalOrWrapperEnforcer.sol";
 import { MultiTokenPeriodEnforcer } from "../src/enforcers/MultiTokenPeriodEnforcer.sol";
 import { NativeBalanceGteEnforcer } from "../src/enforcers/NativeBalanceGteEnforcer.sol";
 import { NativeTokenPaymentEnforcer } from "../src/enforcers/NativeTokenPaymentEnforcer.sol";
@@ -117,6 +118,9 @@ contract DeployCaveatEnforcers is Script {
 
         deployedAddress = address(new LimitedCallsEnforcer{ salt: salt }());
         console2.log("LimitedCallsEnforcer: %s", deployedAddress);
+
+        deployedAddress = address(new LogicalOrWrapperEnforcer{ salt: salt }(delegationManager));
+        console2.log("LogicalOrWrapperEnforcer: %s", deployedAddress);
 
         deployedAddress = address(new MultiTokenPeriodEnforcer{ salt: salt }());
         console2.log("MultiTokenPeriodEnforcer: %s", deployedAddress);

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -218,7 +218,7 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         CaveatGroup[] memory caveatGroups_ = abi.decode(_terms, (CaveatGroup[]));
         SelectedGroup memory selectedGroup_ = abi.decode(_args, (SelectedGroup));
 
-        require(selectedGroup_.groupIndex <= caveatGroups_.length, "LogicalOrWrapperEnforcer:invalid-group-index");
+        require(selectedGroup_.groupIndex < caveatGroups_.length, "LogicalOrWrapperEnforcer:invalid-group-index");
 
         CaveatGroup memory caveatGroup_ = caveatGroups_[selectedGroup_.groupIndex];
         uint256 caveatsLength_ = caveatGroup_.caveats.length;

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
+import { IDelegationManager } from "../interfaces/IDelegationManager.sol";
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode, Caveat } from "../utils/Types.sol";
 
@@ -72,6 +73,15 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
     }
 
     ////////////////////////////// State //////////////////////////////
+
+    /// @dev The Delegation Manager contract to redeem the delegation
+    IDelegationManager public immutable delegationManager;
+
+    ////////////////////////////// Constructor //////////////////////////////
+
+    constructor(IDelegationManager _delegationManager) {
+        delegationManager = _delegationManager;
+    }
 
     ////////////////////////////// Public Methods //////////////////////////////
 

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -31,7 +31,7 @@ import { ModeCode, Caveat } from "../utils/Types.sol";
  * @dev Behavior:
  *  - The enforcer iterates over all caveats in the specified `CaveatGroup`.
  *  - For a group to pass, all caveats within that group must succeed.
- *  - Every caveat is evaluated,
+ *  - Every caveat in the group is evaluated,
  *  - The group index provided via `SelectedGroup.groupIndex` must be valid (i.e. less than or equal to the length of the terms
  * array).
  *  - The length of `SelectedGroup.caveatArgs` must exactly match the number of caveats in the corresponding `CaveatGroup`.

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -99,8 +99,11 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         override
         onlyDefaultExecutionMode(_mode)
     {
-        _callHook(
-            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.beforeAllHook.selector
+        _executeHook(
+            _terms,
+            _args,
+            Params(_mode, _executionCallData, _delegationHash, _delegator, _redeemer),
+            CaveatEnforcer.beforeAllHook.selector
         );
     }
 
@@ -128,8 +131,11 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         override
         onlyDefaultExecutionMode(_mode)
     {
-        _callHook(
-            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.beforeHook.selector
+        _executeHook(
+            _terms,
+            _args,
+            Params(_mode, _executionCallData, _delegationHash, _delegator, _redeemer),
+            CaveatEnforcer.beforeHook.selector
         );
     }
 
@@ -157,8 +163,11 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         override
         onlyDefaultExecutionMode(_mode)
     {
-        _callHook(
-            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.afterHook.selector
+        _executeHook(
+            _terms,
+            _args,
+            Params(_mode, _executionCallData, _delegationHash, _delegator, _redeemer),
+            CaveatEnforcer.afterHook.selector
         );
     }
 
@@ -186,46 +195,15 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         override
         onlyDefaultExecutionMode(_mode)
     {
-        _callHook(
-            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.afterAllHook.selector
+        _executeHook(
+            _terms,
+            _args,
+            Params(_mode, _executionCallData, _delegationHash, _delegator, _redeemer),
+            CaveatEnforcer.afterAllHook.selector
         );
     }
 
     ////////////////////////////// Internal Methods //////////////////////////////
-
-    /**
-     * @notice A wrapper that builds the Params struct and calls _executeHook with the provided hook selector
-     * @dev This function serves as an adapter between the public hook functions and the internal execution logic
-     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
-     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
-     * @param _mode The execution mode
-     * @param _executionCallData The execution data
-     * @param _delegationHash The hash identifying the delegation
-     * @param _delegator The address of the delegator
-     * @param _redeemer The address redeeming the delegation
-     * @param _hookSelector The function selector for the hook to execute
-     */
-    function _callHook(
-        bytes calldata _terms,
-        bytes calldata _args,
-        ModeCode _mode,
-        bytes calldata _executionCallData,
-        bytes32 _delegationHash,
-        address _delegator,
-        address _redeemer,
-        bytes4 _hookSelector
-    )
-        internal
-    {
-        Params memory params_ = Params({
-            mode: _mode,
-            executionCallData: _executionCallData,
-            delegationHash: _delegationHash,
-            delegator: _delegator,
-            redeemer: _redeemer
-        });
-        _executeHook(_terms, _args, params_, _hookSelector);
-    }
 
     /**
      * @notice Internal function that executes the specified hook on all caveats in a group

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { CaveatEnforcer } from "./CaveatEnforcer.sol";
+import { ModeCode, Caveat } from "../utils/Types.sol";
+
+/**
+ * @title LogicalOrWrapperEnforcer
+ * @dev This enforcer operates in the default execution mode only.
+ *
+ * @dev Overview:
+ *  - The hook functions expect two encoded parameters:
+ *    1. **Terms**: Encoded as an array of `CaveatGroup`. Each `CaveatGroup` struct holds an array of `Caveat` structs.
+ *       Each `Caveat` includes the enforcer address and its specific terms.
+ *    2. **Args**: Encoded as a `SelectedGroup` struct. `SelectedGroup` specifies:
+ *          - `groupIndex`: Which element (i.e. which `CaveatGroup`) in the terms array should be evaluated.
+ *          - `caveatArgs`: An array of bytes corresponding to each caveat's arguments within the selected group.
+ *
+ * @dev Usage Flow:
+ *  1. Define your caveats in logical groups by populating an array of `CaveatGroup`.
+ *  2. For each group, include the appropriate enforcer details and terms.
+ *  3. When calling a hook (e.g. `beforeAllHook`), pass the terms as a `CaveatGroup[]` and the group selection
+ *     & arguments as a `SelectedGroup`.
+ *  4. The contract uses the group index to retrieve the proper `CaveatGroup` and iterates over each `Caveat`,
+ *     calling the corresponding enforcer with its specific term and argument.
+ *
+ * @dev Behavior:
+ *  - The enforcer iterates over all caveats in the specified `CaveatGroup`.
+ *  - For a group to pass, all caveats within that group must succeed.
+ *  - Every caveat is evaluated,
+ *  - The group index provided via `SelectedGroup.groupIndex` must be valid (i.e. less than or equal to the length of the terms
+ * array).
+ *  - The length of `SelectedGroup.caveatArgs` must exactly match the number of caveats in the corresponding `CaveatGroup`.
+ *    Empty bytes can be used for caveats that do not require arguments.
+ */
+contract LogicalOrWrapperEnforcer is CaveatEnforcer {
+    using ExecutionLib for bytes;
+
+    /**
+     * @notice Struct representing a group of caveats that will be evaluated together
+     * @dev Each group contains an array of Caveat structs that will be evaluated in sequence
+     * @dev The terms parameter passed to this enforcer's hook functions is an array of these groups
+     */
+    struct CaveatGroup {
+        Caveat[] caveats;
+    }
+
+    /**
+     * @notice Struct used to specify which group to evaluate and provide arguments for its caveats
+     * @dev Contains the index of the group to evaluate from the terms array and the corresponding arguments for each caveat
+     * @dev The args are the arguments for each of the caveats in the group, use empty bytes for no arguments, the length of the
+     * caveatArgs array must match the number of caveats in the group
+     */
+    struct SelectedGroup {
+        uint256 groupIndex;
+        bytes[] caveatArgs;
+    }
+
+    /**
+     * @notice Struct used internally to pass common parameters to hook functions
+     * @dev Consolidates parameters that are common across all hook calls
+     */
+    struct Params {
+        ModeCode mode;
+        bytes executionCallData;
+        bytes32 delegationHash;
+        address delegator;
+        address redeemer;
+    }
+
+    ////////////////////////////// State //////////////////////////////
+
+    ////////////////////////////// Public Methods //////////////////////////////
+
+    /**
+     * @notice Hook called before all delegations are executed
+     * @dev Validates that the execution mode is default and calls the appropriate hook on all caveats
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _mode The execution mode
+     * @param _executionCallData The execution data
+     * @param _delegationHash The hash identifying the delegation
+     * @param _delegator The address of the delegator
+     * @param _redeemer The address redeeming the delegation
+     */
+    function beforeAllHook(
+        bytes calldata _terms,
+        bytes calldata _args,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash,
+        address _delegator,
+        address _redeemer
+    )
+        public
+        override
+        onlyDefaultExecutionMode(_mode)
+    {
+        _callHook(
+            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.beforeAllHook.selector
+        );
+    }
+
+    /**
+     * @notice Hook called before each delegation is executed
+     * @dev Validates that the execution mode is default and calls the appropriate hook on all caveats
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _mode The execution mode
+     * @param _executionCallData The execution data
+     * @param _delegationHash The hash identifying the delegation
+     * @param _delegator The address of the delegator
+     * @param _redeemer The address redeeming the delegation
+     */
+    function beforeHook(
+        bytes calldata _terms,
+        bytes calldata _args,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash,
+        address _delegator,
+        address _redeemer
+    )
+        public
+        override
+        onlyDefaultExecutionMode(_mode)
+    {
+        _callHook(
+            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.beforeHook.selector
+        );
+    }
+
+    /**
+     * @notice Hook called after each delegation is executed
+     * @dev Validates that the execution mode is default and calls the appropriate hook on all caveats
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _mode The execution mode
+     * @param _executionCallData The execution data
+     * @param _delegationHash The hash identifying the delegation
+     * @param _delegator The address of the delegator
+     * @param _redeemer The address redeeming the delegation
+     */
+    function afterHook(
+        bytes calldata _terms,
+        bytes calldata _args,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash,
+        address _delegator,
+        address _redeemer
+    )
+        public
+        override
+        onlyDefaultExecutionMode(_mode)
+    {
+        _callHook(
+            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.afterHook.selector
+        );
+    }
+
+    /**
+     * @notice Hook called after all delegations are executed
+     * @dev Validates that the execution mode is default and calls the appropriate hook on all caveats
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _mode The execution mode
+     * @param _executionCallData The execution data
+     * @param _delegationHash The hash identifying the delegation
+     * @param _delegator The address of the delegator
+     * @param _redeemer The address redeeming the delegation
+     */
+    function afterAllHook(
+        bytes calldata _terms,
+        bytes calldata _args,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash,
+        address _delegator,
+        address _redeemer
+    )
+        public
+        override
+        onlyDefaultExecutionMode(_mode)
+    {
+        _callHook(
+            _terms, _args, _mode, _executionCallData, _delegationHash, _delegator, _redeemer, CaveatEnforcer.afterAllHook.selector
+        );
+    }
+
+    ////////////////////////////// Internal Methods //////////////////////////////
+
+    /**
+     * @notice A wrapper that builds the Params struct and calls _executeHook with the provided hook selector
+     * @dev This function serves as an adapter between the public hook functions and the internal execution logic
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _mode The execution mode
+     * @param _executionCallData The execution data
+     * @param _delegationHash The hash identifying the delegation
+     * @param _delegator The address of the delegator
+     * @param _redeemer The address redeeming the delegation
+     * @param _hookSelector The function selector for the hook to execute
+     */
+    function _callHook(
+        bytes calldata _terms,
+        bytes calldata _args,
+        ModeCode _mode,
+        bytes calldata _executionCallData,
+        bytes32 _delegationHash,
+        address _delegator,
+        address _redeemer,
+        bytes4 _hookSelector
+    )
+        internal
+    {
+        Params memory params_ = Params({
+            mode: _mode,
+            executionCallData: _executionCallData,
+            delegationHash: _delegationHash,
+            delegator: _delegator,
+            redeemer: _redeemer
+        });
+        _executeHook(_terms, _args, params_, _hookSelector);
+    }
+
+    /**
+     * @notice Internal function that executes the specified hook on all caveats in a group
+     * @dev This function handles the core logic of decoding terms and args, validating indices,
+     *      and executing the specified hook on each caveat in the selected group
+     * @param _terms Encoded array of CaveatGroup, where each group contains multiple caveats to evaluate
+     * @param _args Encoded SelectedGroup specifying which group to evaluate and arguments for its caveats
+     * @param _params The consolidated parameters for the hook execution
+     * @param _hookSelector The function selector for the hook to execute
+     */
+    function _executeHook(bytes calldata _terms, bytes calldata _args, Params memory _params, bytes4 _hookSelector) internal {
+        CaveatGroup[] memory caveatGroups_ = abi.decode(_terms, (CaveatGroup[]));
+        SelectedGroup memory selectedGroup_ = abi.decode(_args, (SelectedGroup));
+
+        require(selectedGroup_.groupIndex <= caveatGroups_.length, "LogicalOrWrapperEnforcer:invalid-group-index");
+
+        CaveatGroup memory caveatGroup_ = caveatGroups_[selectedGroup_.groupIndex];
+        uint256 caveatsLength_ = caveatGroup_.caveats.length;
+        require(selectedGroup_.caveatArgs.length == caveatsLength_, "LogicalOrWrapperEnforcer:invalid-caveat-args-length");
+
+        for (uint256 i = 0; i < caveatsLength_; ++i) {
+            Address.functionCall(
+                caveatGroup_.caveats[i].enforcer,
+                abi.encodeWithSelector(
+                    _hookSelector,
+                    caveatGroup_.caveats[i].terms,
+                    selectedGroup_.caveatArgs[i],
+                    _params.mode,
+                    _params.executionCallData,
+                    _params.delegationHash,
+                    _params.delegator,
+                    _params.redeemer
+                )
+            );
+        }
+    }
+}

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -83,6 +83,13 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         delegationManager = _delegationManager;
     }
 
+    ////////////////////////////// Modifiers //////////////////////////////
+
+    modifier onlyDelegationManager() {
+        require(msg.sender == address(delegationManager), "LogicalOrWrapperEnforcer:only-delegation-manager");
+        _;
+    }
+
     ////////////////////////////// Public Methods //////////////////////////////
 
     /**
@@ -108,6 +115,7 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         public
         override
         onlyDefaultExecutionMode(_mode)
+        onlyDelegationManager
     {
         _executeHook(
             _terms,
@@ -140,6 +148,7 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         public
         override
         onlyDefaultExecutionMode(_mode)
+        onlyDelegationManager
     {
         _executeHook(
             _terms,
@@ -172,6 +181,7 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         public
         override
         onlyDefaultExecutionMode(_mode)
+        onlyDelegationManager
     {
         _executeHook(
             _terms,
@@ -204,6 +214,7 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
         public
         override
         onlyDefaultExecutionMode(_mode)
+        onlyDelegationManager
     {
         _executeHook(
             _terms,

--- a/test/enforcers/LogicalOrWrapperEnforcer.t.sol
+++ b/test/enforcers/LogicalOrWrapperEnforcer.t.sol
@@ -10,14 +10,20 @@ import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
 import { LogicalOrWrapperEnforcer } from "../../src/enforcers/LogicalOrWrapperEnforcer.sol";
 import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
 import { AllowedMethodsEnforcer } from "../../src/enforcers/AllowedMethodsEnforcer.sol";
+import { AllowedTargetsEnforcer } from "../../src/enforcers/AllowedTargetsEnforcer.sol";
+import { NativeTokenTransferAmountEnforcer } from "../../src/enforcers/NativeTokenTransferAmountEnforcer.sol";
 import { TimestampEnforcer } from "../../src/enforcers/TimestampEnforcer.sol";
+import { ArgsEqualityCheckEnforcer } from "../../src/enforcers/ArgsEqualityCheckEnforcer.sol";
 
 contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
     ////////////////////// State //////////////////////
 
     LogicalOrWrapperEnforcer public logicalOrWrapperEnforcer;
     AllowedMethodsEnforcer public allowedMethodsEnforcer;
+    AllowedTargetsEnforcer public allowedTargetsEnforcer;
     TimestampEnforcer public timestampEnforcer;
+    ArgsEqualityCheckEnforcer public argsEqualityCheckEnforcer;
+    NativeTokenTransferAmountEnforcer public nativeTokenTransferAmountEnforcer;
 
     ////////////////////// Set up //////////////////////
 
@@ -25,51 +31,59 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         super.setUp();
         logicalOrWrapperEnforcer = new LogicalOrWrapperEnforcer(delegationManager);
         allowedMethodsEnforcer = new AllowedMethodsEnforcer();
+        allowedTargetsEnforcer = new AllowedTargetsEnforcer();
         timestampEnforcer = new TimestampEnforcer();
+        argsEqualityCheckEnforcer = new ArgsEqualityCheckEnforcer();
+        nativeTokenTransferAmountEnforcer = new NativeTokenTransferAmountEnforcer();
         vm.label(address(logicalOrWrapperEnforcer), "Logical OR Wrapper Enforcer");
         vm.label(address(allowedMethodsEnforcer), "Allowed Methods Enforcer");
         vm.label(address(timestampEnforcer), "Timestamp Enforcer");
+        vm.label(address(argsEqualityCheckEnforcer), "Args Equality Check Enforcer");
+        vm.label(address(allowedTargetsEnforcer), "Allowed Targets Enforcer");
+        vm.label(address(nativeTokenTransferAmountEnforcer), "Native Token Transfer Amount Enforcer");
     }
 
     ////////////////////// Helper Functions //////////////////////
 
     function _createCaveatGroup(
-        address[] memory enforcers,
-        bytes[] memory terms
+        address[] memory _enforcers,
+        bytes[] memory _terms
     )
         internal
         pure
         returns (LogicalOrWrapperEnforcer.CaveatGroup memory)
     {
-        require(enforcers.length == terms.length, "LogicalOrWrapperEnforcerTest:invalid-input-length");
-        Caveat[] memory caveats = new Caveat[](enforcers.length);
-        for (uint256 i = 0; i < enforcers.length; ++i) {
-            caveats[i] = Caveat({ enforcer: enforcers[i], terms: terms[i], args: hex"" });
+        require(_enforcers.length == _terms.length, "LogicalOrWrapperEnforcerTest:invalid-input-length");
+        Caveat[] memory caveats = new Caveat[](_enforcers.length);
+        for (uint256 i = 0; i < _enforcers.length; ++i) {
+            caveats[i] = Caveat({ enforcer: _enforcers[i], terms: _terms[i], args: hex"" });
         }
         return LogicalOrWrapperEnforcer.CaveatGroup({ caveats: caveats });
     }
 
     function _createSelectedGroup(
-        uint256 groupIndex,
-        bytes[] memory caveatArgs
+        uint256 _groupIndex,
+        bytes[] memory _caveatArgs
     )
         internal
         pure
         returns (LogicalOrWrapperEnforcer.SelectedGroup memory)
     {
-        return LogicalOrWrapperEnforcer.SelectedGroup({ groupIndex: groupIndex, caveatArgs: caveatArgs });
+        return LogicalOrWrapperEnforcer.SelectedGroup({ groupIndex: _groupIndex, caveatArgs: _caveatArgs });
     }
 
     ////////////////////// Valid cases //////////////////////
 
+    /// @notice Tests that a single caveat group with one caveat works correctly by verifying that a group with a single allowed
+    /// methods caveat can be evaluated
     function test_singleCaveatGroupWithSingleCaveat() public {
         // Create a group with a single caveat (allowed methods)
-        address[] memory enforcers = new address[](1);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        bytes[] memory terms = new bytes[](1);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](1);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms_ = new bytes[](1);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -80,14 +94,14 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Create selected group with no arguments
-        bytes[] memory caveatArgs = new bytes[](1);
-        caveatArgs[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
 
         // Call the hook
         vm.prank(address(delegationManager));
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup_),
             singleDefaultMode,
             executionCallData_,
@@ -97,16 +111,18 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    /// @notice Tests that a single caveat group with multiple caveats works correctly by verifying that a group with both allowed
+    /// methods and timestamp caveats can be evaluated
     function test_singleCaveatGroupWithMultipleCaveats() public {
         // Create a group with multiple caveats (allowed methods and timestamp)
-        address[] memory enforcers = new address[](2);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        enforcers[1] = address(timestampEnforcer);
-        bytes[] memory terms = new bytes[](2);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        terms[1] = abi.encode(block.timestamp + 1 days);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](2);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        enforcers_[1] = address(timestampEnforcer);
+        bytes[] memory terms_ = new bytes[](2);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        terms_[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -117,15 +133,15 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Create selected group with no arguments
-        bytes[] memory caveatArgs = new bytes[](2);
-        caveatArgs[0] = hex"";
-        caveatArgs[1] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+        bytes[] memory caveatArgs_ = new bytes[](2);
+        caveatArgs_[0] = hex"";
+        caveatArgs_[1] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
 
         // Call the hook
         vm.prank(address(delegationManager));
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup_),
             singleDefaultMode,
             executionCallData_,
@@ -135,23 +151,25 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    /// @notice Tests that multiple caveat groups can be evaluated independently by verifying that different groups with different
+    /// caveats can be selected and evaluated
     function test_multipleCaveatGroups() public {
         // Create two groups with different caveats
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](2);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](2);
 
         // First group: allowed methods
-        address[] memory enforcers1 = new address[](1);
-        enforcers1[0] = address(allowedMethodsEnforcer);
-        bytes[] memory terms1 = new bytes[](1);
-        terms1[0] = abi.encodePacked(Counter.increment.selector);
-        groups[0] = _createCaveatGroup(enforcers1, terms1);
+        address[] memory enforcers1_ = new address[](1);
+        enforcers1_[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms1_ = new bytes[](1);
+        terms1_[0] = abi.encodePacked(Counter.increment.selector);
+        groups_[0] = _createCaveatGroup(enforcers1_, terms1_);
 
         // Second group: timestamp
-        address[] memory enforcers2 = new address[](1);
-        enforcers2[0] = address(timestampEnforcer);
-        bytes[] memory terms2 = new bytes[](1);
-        terms2[0] = abi.encode(block.timestamp + 1 days);
-        groups[1] = _createCaveatGroup(enforcers2, terms2);
+        address[] memory enforcers2_ = new address[](1);
+        enforcers2_[0] = address(timestampEnforcer);
+        bytes[] memory terms2_ = new bytes[](1);
+        terms2_[0] = abi.encode(block.timestamp + 1 days);
+        groups_[1] = _createCaveatGroup(enforcers2_, terms2_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -162,13 +180,13 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Test first group
-        bytes[] memory caveatArgs1 = new bytes[](1);
-        caveatArgs1[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup1_ = _createSelectedGroup(0, caveatArgs1);
+        bytes[] memory caveatArgs1_ = new bytes[](1);
+        caveatArgs1_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup1_ = _createSelectedGroup(0, caveatArgs1_);
 
         vm.prank(address(delegationManager));
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup1_),
             singleDefaultMode,
             executionCallData_,
@@ -178,14 +196,87 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         );
 
         // Test second group
-        bytes[] memory caveatArgs2 = new bytes[](1);
-        caveatArgs2[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup2_ = _createSelectedGroup(1, caveatArgs2);
+        bytes[] memory caveatArgs2_ = new bytes[](1);
+        caveatArgs2_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup2_ = _createSelectedGroup(1, caveatArgs2_);
 
         vm.prank(address(delegationManager));
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup2_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    /// @notice Tests that the ArgsEqualityCheckEnforcer works correctly when terms match args through the LogicalOrWrapperEnforcer
+    function test_argsEqualityCheckEnforcerSuccess() public {
+        // Create a group with a single caveat (args equality check)
+        address[] memory enforcers_ = new address[](1);
+        enforcers_[0] = address(argsEqualityCheckEnforcer);
+        bytes[] memory terms_ = new bytes[](1);
+        terms_[0] = abi.encode("test123"); // Terms to match against
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with matching args
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = abi.encode("test123"); // Args that match the terms
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups_),
+            abi.encode(selectedGroup_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    /// @notice Tests that the ArgsEqualityCheckEnforcer fails when terms don't match args through the LogicalOrWrapperEnforcer
+    function test_argsEqualityCheckEnforcerFailure() public {
+        // Create a group with a single caveat (args equality check)
+        address[] memory enforcers_ = new address[](1);
+        enforcers_[0] = address(argsEqualityCheckEnforcer);
+        bytes[] memory terms_ = new bytes[](1);
+        terms_[0] = abi.encode("test123"); // Terms to match against
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with non-matching args
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = abi.encode("different"); // Args that don't match the terms
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        vm.expectRevert("ArgsEqualityCheckEnforcer:different-args-and-terms");
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups_),
+            abi.encode(selectedGroup_),
             singleDefaultMode,
             executionCallData_,
             keccak256(""),
@@ -196,14 +287,16 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
 
     ////////////////////// Invalid cases //////////////////////
 
+    /// @notice Tests that an invalid group index reverts with the expected error by verifying that selecting a group index beyond
+    /// the available groups reverts
     function test_invalidGroupIndex() public {
         // Create a single group
-        address[] memory enforcers = new address[](1);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        bytes[] memory terms = new bytes[](1);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](1);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms_ = new bytes[](1);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -214,15 +307,15 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Create selected group with invalid index
-        bytes[] memory caveatArgs = new bytes[](1);
-        caveatArgs[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(1, caveatArgs);
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(1, caveatArgs_);
 
         // Call the hook
         vm.prank(address(delegationManager));
         vm.expectRevert("LogicalOrWrapperEnforcer:invalid-group-index");
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup_),
             singleDefaultMode,
             executionCallData_,
@@ -232,16 +325,18 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    /// @notice Tests that mismatched caveat arguments length reverts with the expected error by verifying that providing incorrect
+    /// number of arguments for caveats reverts
     function test_invalidCaveatArgsLength() public {
         // Create a group with two caveats
-        address[] memory enforcers = new address[](2);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        enforcers[1] = address(timestampEnforcer);
-        bytes[] memory terms = new bytes[](2);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        terms[1] = abi.encode(block.timestamp + 1 days);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](2);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        enforcers_[1] = address(timestampEnforcer);
+        bytes[] memory terms_ = new bytes[](2);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        terms_[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -252,15 +347,15 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Create selected group with wrong number of arguments
-        bytes[] memory caveatArgs = new bytes[](1);
-        caveatArgs[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
 
         // Call the hook
         vm.prank(address(delegationManager));
         vm.expectRevert("LogicalOrWrapperEnforcer:invalid-caveat-args-length");
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups),
+            abi.encode(groups_),
             abi.encode(selectedGroup_),
             singleDefaultMode,
             executionCallData_,
@@ -270,14 +365,16 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         );
     }
 
+    /// @notice Tests that invalid execution mode reverts with the expected error by verifying that non-default execution modes are
+    /// not allowed
     function test_invalidExecutionMode() public {
         // Create a group with a single caveat
-        address[] memory enforcers = new address[](1);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        bytes[] memory terms = new bytes[](1);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](1);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms_ = new bytes[](1);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution data
         Execution memory execution_ = Execution({
@@ -288,32 +385,49 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
 
         // Create selected group
-        bytes[] memory caveatArgs = new bytes[](1);
-        caveatArgs[0] = hex"";
-        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+        bytes[] memory caveatArgs_ = new bytes[](1);
+        caveatArgs_[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs_);
 
         // Call the hook with invalid singleTryMode
         vm.prank(address(delegationManager));
         vm.expectRevert("CaveatEnforcer:invalid-execution-type");
         logicalOrWrapperEnforcer.beforeHook(
-            abi.encode(groups), abi.encode(selectedGroup_), singleTryMode, executionCallData_, keccak256(""), address(0), address(0)
+            abi.encode(groups_),
+            abi.encode(selectedGroup_),
+            singleTryMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
         );
+    }
+
+    /// @notice Tests that only the delegation manager can call the beforeHook function by verifying that calls from non-delegation
+    /// manager addresses revert with the expected error
+    function test_onlyDelegationManager() public {
+        // Call the hook from a non-delegation manager address
+        vm.prank(address(0x1234));
+        vm.expectRevert("LogicalOrWrapperEnforcer:only-delegation-manager");
+        logicalOrWrapperEnforcer.beforeHook(hex"", hex"", singleDefaultMode, hex"", keccak256(""), address(0), address(0));
     }
 
     ////////////////////// Integration //////////////////////
 
+    /// @notice Tests the integration of the logical OR wrapper with the delegation framework by verifying that the enforcer works
+    /// correctly in a real delegation scenario
     function test_integrationWithDelegation() public {
         uint256 initialValue_ = aliceDeleGatorCounter.count();
 
         // Create a group with multiple caveats
-        address[] memory enforcers = new address[](2);
-        enforcers[0] = address(allowedMethodsEnforcer);
-        enforcers[1] = address(timestampEnforcer);
-        bytes[] memory terms = new bytes[](2);
-        terms[0] = abi.encodePacked(Counter.increment.selector);
-        terms[1] = abi.encode(block.timestamp + 1 days);
-        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
-        groups[0] = _createCaveatGroup(enforcers, terms);
+        address[] memory enforcers_ = new address[](2);
+        enforcers_[0] = address(allowedMethodsEnforcer);
+        enforcers_[1] = address(timestampEnforcer);
+        bytes[] memory terms_ = new bytes[](2);
+        terms_[0] = abi.encodePacked(Counter.increment.selector);
+        terms_[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups_[0] = _createCaveatGroup(enforcers_, terms_);
 
         // Create execution
         Execution memory execution_ = Execution({
@@ -326,7 +440,7 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
         Caveat[] memory caveats_ = new Caveat[](1);
         caveats_[0] = Caveat({
             enforcer: address(logicalOrWrapperEnforcer),
-            terms: abi.encode(groups),
+            terms: abi.encode(groups_),
             args: abi.encode(_createSelectedGroup(0, new bytes[](2)))
         });
 
@@ -354,6 +468,83 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
 
         // Validate that the count has increased by 1
         assertEq(valueAfter_, initialValue_ + 1);
+    }
+
+    /// @notice Tests the integration of the logical OR wrapper with method/target permissions and ETH transfers
+    function test_integrationWithMethodAndEthTransfer() public {
+        // Record initial balances
+        uint256 initialAliceBalance_ = address(users.alice.deleGator).balance;
+        uint256 initialCarolBalance_ = address(users.carol.deleGator).balance;
+        uint256 initialCounterValue_ = aliceDeleGatorCounter.count();
+
+        // Create two caveat groups
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups_ = new LogicalOrWrapperEnforcer.CaveatGroup[](2);
+
+        // Group 0: Allow increment method on counter
+        address[] memory enforcers0_ = new address[](2);
+        enforcers0_[0] = address(allowedMethodsEnforcer);
+        enforcers0_[1] = address(allowedTargetsEnforcer);
+        bytes[] memory terms0_ = new bytes[](2);
+        terms0_[0] = abi.encodePacked(Counter.increment.selector);
+        terms0_[1] = abi.encodePacked(address(aliceDeleGatorCounter));
+        groups_[0] = _createCaveatGroup(enforcers0_, terms0_);
+
+        // Group 1: Allow ETH transfer up to 1 ether
+        address[] memory enforcers1_ = new address[](1);
+        enforcers1_[0] = address(nativeTokenTransferAmountEnforcer);
+        bytes[] memory terms1_ = new bytes[](1);
+        terms1_[0] = abi.encode(1 ether);
+        groups_[1] = _createCaveatGroup(enforcers1_, terms1_);
+
+        // Create execution for counter increment
+        Execution memory counterExecution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+
+        // Create execution for ETH transfer to Carol
+        Execution memory ethExecution_ = Execution({ target: address(users.carol.deleGator), value: 0.5 ether, callData: hex"" });
+
+        // Create caveat for the logical OR wrapper
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({
+            enforcer: address(logicalOrWrapperEnforcer),
+            terms: abi.encode(groups_),
+            args: abi.encode(_createSelectedGroup(0, new bytes[](2))) // Use group 0 for counter
+         });
+
+        // Create delegation
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Execute Bob's UserOp for counter increment
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+        invokeDelegation_UserOp(users.bob, delegations_, counterExecution_);
+
+        // Update caveat args to use group 1 for ETH transfer
+        delegations_[0].caveats[0].args = abi.encode(_createSelectedGroup(1, new bytes[](1)));
+
+        // Execute Bob's UserOp for ETH transfer to Carol
+        invokeDelegation_UserOp(users.bob, delegations_, ethExecution_);
+
+        // Validate results
+        assertEq(aliceDeleGatorCounter.count(), initialCounterValue_ + 1, "Counter should increment");
+        assertEq(
+            address(users.alice.deleGator).balance, initialAliceBalance_ - 0.5 ether, "Alice's balance should decrease by 0.5 ether"
+        );
+        assertEq(
+            address(users.carol.deleGator).balance, initialCarolBalance_ + 0.5 ether, "Carol's balance should increase by 0.5 ether"
+        );
     }
 
     function _getEnforcer() internal view override returns (ICaveatEnforcer) {

--- a/test/enforcers/LogicalOrWrapperEnforcer.t.sol
+++ b/test/enforcers/LogicalOrWrapperEnforcer.t.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+pragma solidity 0.8.23;
+
+import { Test } from "forge-std/Test.sol";
+import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
+
+import { Execution, Caveat, Delegation } from "../../src/utils/Types.sol";
+import { Counter } from "../utils/Counter.t.sol";
+import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";
+import { LogicalOrWrapperEnforcer } from "../../src/enforcers/LogicalOrWrapperEnforcer.sol";
+import { ICaveatEnforcer } from "../../src/interfaces/ICaveatEnforcer.sol";
+import { AllowedMethodsEnforcer } from "../../src/enforcers/AllowedMethodsEnforcer.sol";
+import { TimestampEnforcer } from "../../src/enforcers/TimestampEnforcer.sol";
+
+contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
+    ////////////////////// State //////////////////////
+
+    LogicalOrWrapperEnforcer public logicalOrWrapperEnforcer;
+    AllowedMethodsEnforcer public allowedMethodsEnforcer;
+    TimestampEnforcer public timestampEnforcer;
+
+    ////////////////////// Set up //////////////////////
+
+    function setUp() public override {
+        super.setUp();
+        logicalOrWrapperEnforcer = new LogicalOrWrapperEnforcer();
+        allowedMethodsEnforcer = new AllowedMethodsEnforcer();
+        timestampEnforcer = new TimestampEnforcer();
+        vm.label(address(logicalOrWrapperEnforcer), "Logical OR Wrapper Enforcer");
+        vm.label(address(allowedMethodsEnforcer), "Allowed Methods Enforcer");
+        vm.label(address(timestampEnforcer), "Timestamp Enforcer");
+    }
+
+    ////////////////////// Helper Functions //////////////////////
+
+    function _createCaveatGroup(
+        address[] memory enforcers,
+        bytes[] memory terms
+    )
+        internal
+        pure
+        returns (LogicalOrWrapperEnforcer.CaveatGroup memory)
+    {
+        require(enforcers.length == terms.length, "LogicalOrWrapperEnforcerTest:invalid-input-length");
+        Caveat[] memory caveats = new Caveat[](enforcers.length);
+        for (uint256 i = 0; i < enforcers.length; ++i) {
+            caveats[i] = Caveat({ enforcer: enforcers[i], terms: terms[i], args: hex"" });
+        }
+        return LogicalOrWrapperEnforcer.CaveatGroup({ caveats: caveats });
+    }
+
+    function _createSelectedGroup(
+        uint256 groupIndex,
+        bytes[] memory caveatArgs
+    )
+        internal
+        pure
+        returns (LogicalOrWrapperEnforcer.SelectedGroup memory)
+    {
+        return LogicalOrWrapperEnforcer.SelectedGroup({ groupIndex: groupIndex, caveatArgs: caveatArgs });
+    }
+
+    ////////////////////// Valid cases //////////////////////
+
+    function test_singleCaveatGroupWithSingleCaveat() public {
+        // Create a group with a single caveat (allowed methods)
+        address[] memory enforcers = new address[](1);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms = new bytes[](1);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with no arguments
+        bytes[] memory caveatArgs = new bytes[](1);
+        caveatArgs[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    function test_singleCaveatGroupWithMultipleCaveats() public {
+        // Create a group with multiple caveats (allowed methods and timestamp)
+        address[] memory enforcers = new address[](2);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        enforcers[1] = address(timestampEnforcer);
+        bytes[] memory terms = new bytes[](2);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        terms[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with no arguments
+        bytes[] memory caveatArgs = new bytes[](2);
+        caveatArgs[0] = hex"";
+        caveatArgs[1] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    function test_multipleCaveatGroups() public {
+        // Create two groups with different caveats
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](2);
+
+        // First group: allowed methods
+        address[] memory enforcers1 = new address[](1);
+        enforcers1[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms1 = new bytes[](1);
+        terms1[0] = abi.encodePacked(Counter.increment.selector);
+        groups[0] = _createCaveatGroup(enforcers1, terms1);
+
+        // Second group: timestamp
+        address[] memory enforcers2 = new address[](1);
+        enforcers2[0] = address(timestampEnforcer);
+        bytes[] memory terms2 = new bytes[](1);
+        terms2[0] = abi.encode(block.timestamp + 1 days);
+        groups[1] = _createCaveatGroup(enforcers2, terms2);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Test first group
+        bytes[] memory caveatArgs1 = new bytes[](1);
+        caveatArgs1[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup1_ = _createSelectedGroup(0, caveatArgs1);
+
+        vm.prank(address(delegationManager));
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup1_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+
+        // Test second group
+        bytes[] memory caveatArgs2 = new bytes[](1);
+        caveatArgs2[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup2_ = _createSelectedGroup(1, caveatArgs2);
+
+        vm.prank(address(delegationManager));
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup2_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    ////////////////////// Invalid cases //////////////////////
+
+    function test_invalidGroupIndex() public {
+        // Create a single group
+        address[] memory enforcers = new address[](1);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms = new bytes[](1);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with invalid index
+        bytes[] memory caveatArgs = new bytes[](1);
+        caveatArgs[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(1, caveatArgs);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        vm.expectRevert("LogicalOrWrapperEnforcer:invalid-group-index");
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    function test_invalidCaveatArgsLength() public {
+        // Create a group with two caveats
+        address[] memory enforcers = new address[](2);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        enforcers[1] = address(timestampEnforcer);
+        bytes[] memory terms = new bytes[](2);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        terms[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group with wrong number of arguments
+        bytes[] memory caveatArgs = new bytes[](1);
+        caveatArgs[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+
+        // Call the hook
+        vm.prank(address(delegationManager));
+        vm.expectRevert("LogicalOrWrapperEnforcer:invalid-caveat-args-length");
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups),
+            abi.encode(selectedGroup_),
+            singleDefaultMode,
+            executionCallData_,
+            keccak256(""),
+            address(0),
+            address(0)
+        );
+    }
+
+    function test_invalidExecutionMode() public {
+        // Create a group with a single caveat
+        address[] memory enforcers = new address[](1);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        bytes[] memory terms = new bytes[](1);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution data
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+        bytes memory executionCallData_ = ExecutionLib.encodeSingle(execution_.target, execution_.value, execution_.callData);
+
+        // Create selected group
+        bytes[] memory caveatArgs = new bytes[](1);
+        caveatArgs[0] = hex"";
+        LogicalOrWrapperEnforcer.SelectedGroup memory selectedGroup_ = _createSelectedGroup(0, caveatArgs);
+
+        // Call the hook with invalid singleTryMode
+        vm.prank(address(delegationManager));
+        vm.expectRevert("CaveatEnforcer:invalid-execution-type");
+        logicalOrWrapperEnforcer.beforeHook(
+            abi.encode(groups), abi.encode(selectedGroup_), singleTryMode, executionCallData_, keccak256(""), address(0), address(0)
+        );
+    }
+
+    ////////////////////// Integration //////////////////////
+
+    function test_integrationWithDelegation() public {
+        uint256 initialValue_ = aliceDeleGatorCounter.count();
+
+        // Create a group with multiple caveats
+        address[] memory enforcers = new address[](2);
+        enforcers[0] = address(allowedMethodsEnforcer);
+        enforcers[1] = address(timestampEnforcer);
+        bytes[] memory terms = new bytes[](2);
+        terms[0] = abi.encodePacked(Counter.increment.selector);
+        terms[1] = abi.encode(block.timestamp + 1 days);
+        LogicalOrWrapperEnforcer.CaveatGroup[] memory groups = new LogicalOrWrapperEnforcer.CaveatGroup[](1);
+        groups[0] = _createCaveatGroup(enforcers, terms);
+
+        // Create execution
+        Execution memory execution_ = Execution({
+            target: address(aliceDeleGatorCounter),
+            value: 0,
+            callData: abi.encodeWithSelector(Counter.increment.selector)
+        });
+
+        // Create caveat for the logical OR wrapper
+        Caveat[] memory caveats_ = new Caveat[](1);
+        caveats_[0] = Caveat({
+            enforcer: address(logicalOrWrapperEnforcer),
+            terms: abi.encode(groups),
+            args: abi.encode(_createSelectedGroup(0, new bytes[](2)))
+        });
+
+        // Create delegation
+        Delegation memory delegation_ = Delegation({
+            delegate: address(users.bob.deleGator),
+            delegator: address(users.alice.deleGator),
+            authority: ROOT_AUTHORITY,
+            caveats: caveats_,
+            salt: 0,
+            signature: hex""
+        });
+
+        delegation_ = signDelegation(users.alice, delegation_);
+
+        // Execute Bob's UserOp
+        Delegation[] memory delegations_ = new Delegation[](1);
+        delegations_[0] = delegation_;
+
+        // Enforcer allows the delegation
+        invokeDelegation_UserOp(users.bob, delegations_, execution_);
+
+        // Get count
+        uint256 valueAfter_ = aliceDeleGatorCounter.count();
+
+        // Validate that the count has increased by 1
+        assertEq(valueAfter_, initialValue_ + 1);
+    }
+
+    function _getEnforcer() internal view override returns (ICaveatEnforcer) {
+        return ICaveatEnforcer(address(logicalOrWrapperEnforcer));
+    }
+}

--- a/test/enforcers/LogicalOrWrapperEnforcer.t.sol
+++ b/test/enforcers/LogicalOrWrapperEnforcer.t.sol
@@ -23,7 +23,7 @@ contract LogicalOrWrapperEnforcerTest is CaveatEnforcerBaseTest {
 
     function setUp() public override {
         super.setUp();
-        logicalOrWrapperEnforcer = new LogicalOrWrapperEnforcer();
+        logicalOrWrapperEnforcer = new LogicalOrWrapperEnforcer(delegationManager);
         allowedMethodsEnforcer = new AllowedMethodsEnforcer();
         timestampEnforcer = new TimestampEnforcer();
         vm.label(address(logicalOrWrapperEnforcer), "Logical OR Wrapper Enforcer");


### PR DESCRIPTION
### **What?**

- Added Logical Or Wrapper Enforcer

### **Why?**

- This enforcer allows to specify a group of caveats to be used during the redemption. The delegator grants access to different permissions in different groups, and the redeemer chooses what group of permissions to use for the execution that they need.

### **How?**

- Grouping caveats in the terms and wrapping them inside another enforcer called the LogicalOrWrapperEnforcer
