### PR TITLE
Audit April 2025 - 4.13 Inconsistent Transfer Validation Across Call Types

### DIFF
--- a/src/enforcers/ERC20PeriodTransferEnforcer.sol
+++ b/src/enforcers/ERC20PeriodTransferEnforcer.sol
@@ -178,7 +178,9 @@ contract ERC20PeriodTransferEnforcer is CaveatEnforcer {
     )
         private
     {
-        (address target_,, bytes calldata callData_) = _executionCallData.decodeSingle();
+        (address target_, uint256 value_, bytes calldata callData_) = _executionCallData.decodeSingle();
+
+        require(value_ == 0, "ERC20PeriodTransferEnforcer:invalid-value-in-erc20-transfer");
 
         require(callData_.length == 68, "ERC20PeriodTransferEnforcer:invalid-execution-length");
 

--- a/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
+++ b/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
@@ -166,7 +166,11 @@ contract NativeTokenPeriodTransferEnforcer is CaveatEnforcer {
     )
         private
     {
-        (, uint256 value_,) = _executionCallData.decodeSingle();
+        (, uint256 value_, bytes calldata callData_) = _executionCallData.decodeSingle();
+
+        require(callData_.length == 0, "NativeTokenPeriodTransferEnforcer:invalid-call-data-length");
+
+        require(value_ > 0, "NativeTokenPeriodTransferEnforcer:invalid-zero-value-in-native-transfer");
 
         (uint256 periodAmount_, uint256 periodDuration_, uint256 startDate_) = getTermsInfo(_terms);
 


### PR DESCRIPTION
### **What?**

- Added validations to the TokenPeriodEnforcers:
  - Enforce value zero for ERC20PeriodTransferEnforcer
  - Enforce empty calldata for NativeTokenPeriodTransferEnforcer and value greater than 0.

### **Why?**

- This makes both enforcers more consistent with the MultiTokenPeriodEnforcer.

