### PR TITLE
Audit May 2025 - 7.1.1 and 7.1.2 - No Execution Mode Restriction And Security Notice

### DIFF
--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -31,11 +31,24 @@ import { ModeCode, Caveat } from "../utils/Types.sol";
  * @dev Behavior:
  *  - The enforcer iterates over all caveats in the specified `CaveatGroup`.
  *  - For a group to pass, all caveats within that group must succeed.
- *  - Every caveat in the group is evaluated,
+ *  - Every caveat in the group is evaluated.
  *  - The group index provided via `SelectedGroup.groupIndex` must be valid (i.e. less than or equal to the length of the terms
  * array).
  *  - The length of `SelectedGroup.caveatArgs` must exactly match the number of caveats in the corresponding `CaveatGroup`.
  *    Empty bytes can be used for caveats that do not require arguments.
+ *
+ * @dev Security Notice: This enforcer allows delegates to choose which caveat group to use at
+ * execution time, via the groupIndex parameter. If multiple caveat groups are defined with varying
+ * levels of restrictions, delegates can select the least restrictive group, bypassing stricter
+ * requirements in other groups.
+ *
+ * To maintain proper security:
+ *  - Ensure each caveat group represents a complete and equally secure permission set.
+ *  - Never assume delegates will select the most restrictive group.
+ *  - Design caveat groups with the understanding that delegates will choose the path of least
+ *    resistance.
+ *
+ * Use this enforcer at your own risk and ensure it aligns with your intended security model.
  */
 contract LogicalOrWrapperEnforcer is CaveatEnforcer {
     using ExecutionLib for bytes;
@@ -114,7 +127,6 @@ contract LogicalOrWrapperEnforcer is CaveatEnforcer {
     )
         public
         override
-        onlyDefaultExecutionMode(_mode)
         onlyDelegationManager
     {
         _executeHook(

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -37,15 +37,15 @@ import { ModeCode, Caveat } from "../utils/Types.sol";
  *  - The length of `SelectedGroup.caveatArgs` must exactly match the number of caveats in the corresponding `CaveatGroup`.
  *    Empty bytes can be used for caveats that do not require arguments.
  *
- * @dev Security Notice: This enforcer allows delegates to choose which caveat group to use at
+ * @dev Security Notice: This enforcer allows the redeemer to choose which caveat group to use at
  * execution time, via the groupIndex parameter. If multiple caveat groups are defined with varying
- * levels of restrictions, delegates can select the least restrictive group, bypassing stricter
+ * levels of restrictions, the redeemer can select the least restrictive group, bypassing stricter
  * requirements in other groups.
  *
  * To maintain proper security:
  *  - Ensure each caveat group represents a complete and equally secure permission set.
- *  - Never assume delegates will select the most restrictive group.
- *  - Design caveat groups with the understanding that delegates will choose the path of least
+ *  - Never assume the redeemer will select the most restrictive group.
+ *  - Design caveat groups with the understanding that the redeemer will choose the path of least
  *    resistance.
  *
  * Use this enforcer at your own risk and ensure it aligns with your intended security model.


### PR DESCRIPTION
### **What?**

- Deletes execution mode restriction from the logicalOr enforcer since this would not allow the internal enforcers to control this. 
- A security notice is added that the users might use the less restrictive group of caveats.
