### PR TITLE
Relaxed complier version - Fixes #88

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -58,7 +58,7 @@ In the case that you need to create a custom enforcer, you can use the `CaveatEn
 
 ```solidity
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/script/DeployCaveatEnforcers.s.sol
+++ b/script/DeployCaveatEnforcers.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/script/DeployDelegationFramework.s.sol
+++ b/script/DeployDelegationFramework.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/script/DeployDelegationMetaSwapAdapter.s.sol
+++ b/script/DeployDelegationMetaSwapAdapter.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/script/DeployEIP7702StatelessDeleGator.s.sol
+++ b/script/DeployEIP7702StatelessDeleGator.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/script/DeployMultiSigDeleGator.s.sol
+++ b/script/DeployMultiSigDeleGator.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/script/DeploySimpleFactory.s.sol
+++ b/script/DeploySimpleFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";

--- a/src/DeleGatorCore.sol
+++ b/src/DeleGatorCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/src/DelegationManager.sol
+++ b/src/DelegationManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/src/EIP7702/EIP7702DeleGatorCore.sol
+++ b/src/EIP7702/EIP7702DeleGatorCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/src/EIP7702/EIP7702StatelessDeleGator.sol
+++ b/src/EIP7702/EIP7702StatelessDeleGator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";

--- a/src/HybridDeleGator.sol
+++ b/src/HybridDeleGator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";

--- a/src/MultiSigDeleGator.sol
+++ b/src/MultiSigDeleGator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IEntryPoint } from "@account-abstraction/interfaces/IEntryPoint.sol";

--- a/src/enforcers/AllowedCalldataEnforcer.sol
+++ b/src/enforcers/AllowedCalldataEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/AllowedMethodsEnforcer.sol
+++ b/src/enforcers/AllowedMethodsEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/AllowedTargetsEnforcer.sol
+++ b/src/enforcers/AllowedTargetsEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/ArgsEqualityCheckEnforcer.sol
+++ b/src/enforcers/ArgsEqualityCheckEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/BlockNumberEnforcer.sol
+++ b/src/enforcers/BlockNumberEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/CaveatEnforcer.sol
+++ b/src/enforcers/CaveatEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 

--- a/src/enforcers/DeployedEnforcer.sol
+++ b/src/enforcers/DeployedEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";

--- a/src/enforcers/ERC1155BalanceChangeEnforcer.sol
+++ b/src/enforcers/ERC1155BalanceChangeEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 

--- a/src/enforcers/ERC20BalanceChangeEnforcer.sol
+++ b/src/enforcers/ERC20BalanceChangeEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/enforcers/ERC20PeriodTransferEnforcer.sol
+++ b/src/enforcers/ERC20PeriodTransferEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/ERC20StreamingEnforcer.sol
+++ b/src/enforcers/ERC20StreamingEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/ERC20TransferAmountEnforcer.sol
+++ b/src/enforcers/ERC20TransferAmountEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/ERC721BalanceChangeEnforcer.sol
+++ b/src/enforcers/ERC721BalanceChangeEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/src/enforcers/ERC721TransferEnforcer.sol
+++ b/src/enforcers/ERC721TransferEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/ExactCalldataBatchEnforcer.sol
+++ b/src/enforcers/ExactCalldataBatchEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";

--- a/src/enforcers/ExactCalldataEnforcer.sol
+++ b/src/enforcers/ExactCalldataEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/ExactExecutionBatchEnforcer.sol
+++ b/src/enforcers/ExactExecutionBatchEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";

--- a/src/enforcers/ExactExecutionEnforcer.sol
+++ b/src/enforcers/ExactExecutionEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";

--- a/src/enforcers/IdEnforcer.sol
+++ b/src/enforcers/IdEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { BitMaps } from "@openzeppelin/contracts/utils/structs/BitMaps.sol";
 

--- a/src/enforcers/LimitedCallsEnforcer.sol
+++ b/src/enforcers/LimitedCallsEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/LogicalOrWrapperEnforcer.sol
+++ b/src/enforcers/LogicalOrWrapperEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/src/enforcers/MultiTokenPeriodEnforcer.sol
+++ b/src/enforcers/MultiTokenPeriodEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/NativeBalanceChangeEnforcer.sol
+++ b/src/enforcers/NativeBalanceChangeEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/NativeTokenPaymentEnforcer.sol
+++ b/src/enforcers/NativeTokenPaymentEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ModeLib } from "@erc7579/lib/ModeLib.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
+++ b/src/enforcers/NativeTokenPeriodTransferEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/NativeTokenStreamingEnforcer.sol
+++ b/src/enforcers/NativeTokenStreamingEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";

--- a/src/enforcers/NativeTokenTransferAmountEnforcer.sol
+++ b/src/enforcers/NativeTokenTransferAmountEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/NonceEnforcer.sol
+++ b/src/enforcers/NonceEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/OwnershipTransferEnforcer.sol
+++ b/src/enforcers/OwnershipTransferEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/enforcers/RedeemerEnforcer.sol
+++ b/src/enforcers/RedeemerEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
+++ b/src/enforcers/SpecificActionERC20TransferBatchEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/src/enforcers/TimestampEnforcer.sol
+++ b/src/enforcers/TimestampEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "./CaveatEnforcer.sol";
 import { ModeCode } from "../utils/Types.sol";

--- a/src/enforcers/ValueLteEnforcer.sol
+++ b/src/enforcers/ValueLteEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/src/helpers/DelegationMetaSwapAdapter.sol
+++ b/src/helpers/DelegationMetaSwapAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";

--- a/src/interfaces/ICaveatEnforcer.sol
+++ b/src/interfaces/ICaveatEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ModeCode } from "../utils/Types.sol";
 

--- a/src/interfaces/IDeleGatorCore.sol
+++ b/src/interfaces/IDeleGatorCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 

--- a/src/interfaces/IDelegationManager.sol
+++ b/src/interfaces/IDelegationManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Delegation, Execution, ModeCode } from "../utils/Types.sol";
 

--- a/src/interfaces/IERC173.sol
+++ b/src/interfaces/IERC173.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /// @title ERC-173 Contract Ownership Standard
 /// NOTE: the ERC-165 identifier for this interface is 0x7f5828d0

--- a/src/libraries/ERC1271Lib.sol
+++ b/src/libraries/ERC1271Lib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /**
  * @title ERC1271 Library

--- a/src/libraries/EncoderLib.sol
+++ b/src/libraries/EncoderLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Delegation, Caveat } from "../utils/Types.sol";
 import { DELEGATION_TYPEHASH, CAVEAT_TYPEHASH } from "../utils/Constants.sol";

--- a/src/libraries/P256SCLVerifierLib.sol
+++ b/src/libraries/P256SCLVerifierLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { SCL_RIP7212 } from "@SCL/lib/libSCL_RIP7212.sol";
 import { ec_isOnCurve } from "@SCL/elliptic/SCL_ecOncurve.sol";

--- a/src/libraries/P256VerifierLib.sol
+++ b/src/libraries/P256VerifierLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { WebAuthn } from "./WebAuthn.sol";
 import { P256SCLVerifierLib } from "./P256SCLVerifierLib.sol";

--- a/src/libraries/WebAuthn.sol
+++ b/src/libraries/WebAuthn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Base64URL } from "./utils/Base64URL.sol";
 import { P256SCLVerifierLib } from "./P256SCLVerifierLib.sol";

--- a/src/libraries/utils/Base64URL.sol
+++ b/src/libraries/utils/Base64URL.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "openzeppelin-contracts/contracts/utils/Base64.sol";
 

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {
     CALLTYPE_SINGLE, CALLTYPE_BATCH, EXECTYPE_DEFAULT, EXECTYPE_TRY, MODE_DEFAULT, MODE_OFFSET

--- a/src/utils/SimpleFactory.sol
+++ b/src/utils/SimpleFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 

--- a/src/utils/Types.sol
+++ b/src/utils/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { PackedUserOperation } from "@account-abstraction/interfaces/PackedUserOperation.sol";
 import { Execution } from "@erc7579/interfaces/IERC7579Account.sol";

--- a/test/CounterfactualAssetsTest.t.sol
+++ b/test/CounterfactualAssetsTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { BaseTest } from "./utils/BaseTest.t.sol";
 import { Delegation, Caveat, Execution } from "../src/utils/Types.sol";

--- a/test/DeleGatorTestSuite.t.sol
+++ b/test/DeleGatorTestSuite.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { IEntryPoint, EntryPoint } from "@account-abstraction/core/EntryPoint.sol";

--- a/test/DelegationChainMaxDepthTest.t.sol
+++ b/test/DelegationChainMaxDepthTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 

--- a/test/DelegationChainWithCaveatsTest.t.sol
+++ b/test/DelegationChainWithCaveatsTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 

--- a/test/DelegationManagerTest.t.sol
+++ b/test/DelegationManagerTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";

--- a/test/EIP7702StatelessDeleGatorTest.t.sol
+++ b/test/EIP7702StatelessDeleGatorTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IEntryPoint, EntryPoint } from "@account-abstraction/core/EntryPoint.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";

--- a/test/HybridDeleGatorTest.t.sol
+++ b/test/HybridDeleGatorTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/test/InviteTest.t.sol
+++ b/test/InviteTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";

--- a/test/MixedAuthorityDelegationTest.t.sol
+++ b/test/MixedAuthorityDelegationTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 

--- a/test/MultiSigDeleGatorTest.t.sol
+++ b/test/MultiSigDeleGatorTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IEntryPoint, EntryPoint } from "@account-abstraction/core/EntryPoint.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";

--- a/test/ProxyMigrationTest.t.sol
+++ b/test/ProxyMigrationTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";

--- a/test/RedemptionBatchSizeLimitsTest.t.sol
+++ b/test/RedemptionBatchSizeLimitsTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";

--- a/test/RevokeDelegationMidChainTest.t.sol
+++ b/test/RevokeDelegationMidChainTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Implementation, SignatureType } from "./utils/Types.t.sol";
 import { BaseTest } from "./utils/BaseTest.t.sol";

--- a/test/enforcers/AllowedCalldataEnforcer.t.sol
+++ b/test/enforcers/AllowedCalldataEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/enforcers/AllowedMethodsEnforcer.t.sol
+++ b/test/enforcers/AllowedMethodsEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/enforcers/AllowedTargetsEnforcer.t.sol
+++ b/test/enforcers/AllowedTargetsEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
+++ b/test/enforcers/ArgsEqualityCheckEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "../../src/utils/Types.sol";
 import { CaveatEnforcerBaseTest } from "./CaveatEnforcerBaseTest.t.sol";

--- a/test/enforcers/BlockNumberEnforcer.t.sol
+++ b/test/enforcers/BlockNumberEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/enforcers/CaveatEnforcerBaseTest.t.sol
+++ b/test/enforcers/CaveatEnforcerBaseTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 import { Implementation, SignatureType } from "../utils/Types.t.sol";

--- a/test/enforcers/DeployedEnforcer.t.sol
+++ b/test/enforcers/DeployedEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ERC1155BalanceChangeEnforcer.t.sol
+++ b/test/enforcers/ERC1155BalanceChangeEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import "../../src/utils/Types.sol";

--- a/test/enforcers/ERC20BalanceChangeEnforcer.t.sol
+++ b/test/enforcers/ERC20BalanceChangeEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicERC20 } from "../utils/BasicERC20.t.sol";

--- a/test/enforcers/ERC20PeriodTransferEnforcer.t.sol
+++ b/test/enforcers/ERC20PeriodTransferEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ERC20StreamingEnforcer.t.sol
+++ b/test/enforcers/ERC20StreamingEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ERC20TransferAmountEnforcer.t.sol
+++ b/test/enforcers/ERC20TransferAmountEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ERC721BalanceChangeEnforcer.t.sol
+++ b/test/enforcers/ERC721BalanceChangeEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicCF721 } from "../utils/BasicCF721.t.sol";

--- a/test/enforcers/ERC721TransferEnforcer.t.sol
+++ b/test/enforcers/ERC721TransferEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicCF721 } from "../utils/BasicCF721.t.sol";

--- a/test/enforcers/ExactCalldataBatchEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataBatchEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ExactCalldataEnforcer.t.sol
+++ b/test/enforcers/ExactCalldataEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ExactExecutionBatchEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionBatchEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ExactExecutionEnforcer.t.sol
+++ b/test/enforcers/ExactExecutionEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/IdEnforcer.t.sol
+++ b/test/enforcers/IdEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/LimitedCallsEnforcer.t.sol
+++ b/test/enforcers/LimitedCallsEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/LogicalOrWrapperEnforcer.t.sol
+++ b/test/enforcers/LogicalOrWrapperEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/MultiTokenPeriodEnforcer.t.sol
+++ b/test/enforcers/MultiTokenPeriodEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/enforcers/NativeBalanceChangeEnforcer.t.sol
+++ b/test/enforcers/NativeBalanceChangeEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "../../src/utils/Types.sol";
 import { Execution } from "../../src/utils/Types.sol";

--- a/test/enforcers/NativeTokenPaymentEnforcer.t.sol
+++ b/test/enforcers/NativeTokenPaymentEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/test/enforcers/NativeTokenPeriodTransferEnforcer.t.sol
+++ b/test/enforcers/NativeTokenPeriodTransferEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/NativeTokenStreamingEnforcer.t.sol
+++ b/test/enforcers/NativeTokenStreamingEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/NativeTokenTransferAmountEnforcer.t.sol
+++ b/test/enforcers/NativeTokenTransferAmountEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/test/enforcers/NonceEnforcer.t.sol
+++ b/test/enforcers/NonceEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/OwnershipTransferEnforcer.t.sol
+++ b/test/enforcers/OwnershipTransferEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/PasswordEnforcer.t.sol
+++ b/test/enforcers/PasswordEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/RedeemerEnforcer.t.sol
+++ b/test/enforcers/RedeemerEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";
 

--- a/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
+++ b/test/enforcers/SpecificActionERC20TransferBatchEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/TimestampEnforcer.t.sol
+++ b/test/enforcers/TimestampEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { ExecutionLib } from "@erc7579/lib/ExecutionLib.sol";

--- a/test/enforcers/ValueLteEnforcer.t.sol
+++ b/test/enforcers/ValueLteEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 import { BasicERC20 } from "../utils/BasicERC20.t.sol";

--- a/test/helpers/DelegationMetaSwapAdapter.t.sol
+++ b/test/helpers/DelegationMetaSwapAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/metaTests/EncoderLibTest.t.sol
+++ b/test/metaTests/EncoderLibTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/test/metaTests/StorageUtilsLibTest.t.sol
+++ b/test/metaTests/StorageUtilsLibTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 

--- a/test/metaTests/TypehashTest.t.sol
+++ b/test/metaTests/TypehashTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 

--- a/test/utils/AccountSorterLib.t.sol
+++ b/test/utils/AccountSorterLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 library AccountSorterLib {
     ////////////////////////////// External Methods //////////////////////////////

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/test/utils/BasicCF721.t.sol
+++ b/test/utils/BasicCF721.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/test/utils/BasicERC1155.t.sol
+++ b/test/utils/BasicERC1155.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ERC1155 } from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/test/utils/BasicERC20.t.sol
+++ b/test/utils/BasicERC20.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { ERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 string constant EXECUTE_SIGNATURE = "execute(bytes32,bytes)";
 string constant EXECUTE_SINGULAR_SIGNATURE = "execute((address,uint256,bytes))";

--- a/test/utils/Counter.t.sol
+++ b/test/utils/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 

--- a/test/utils/CounterWithReceive.t.sol
+++ b/test/utils/CounterWithReceive.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 

--- a/test/utils/Eip712Lib.t.sol
+++ b/test/utils/Eip712Lib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 library Eip712Lib {
     bytes32 internal constant DOMAIN_TYPE_HASH =

--- a/test/utils/GasReporter.t.sol
+++ b/test/utils/GasReporter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Vm } from "forge-std/Vm.sol";
 

--- a/test/utils/Invalid1271.t.sol
+++ b/test/utils/Invalid1271.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 

--- a/test/utils/MockCaveatEnforcer.sol
+++ b/test/utils/MockCaveatEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "../../src/enforcers/CaveatEnforcer.sol";
 import { ModeCode } from "../../src/utils/Types.sol";

--- a/test/utils/MockFailureCaveatEnforcer.sol
+++ b/test/utils/MockFailureCaveatEnforcer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "../../src/enforcers/CaveatEnforcer.sol";
 import { ModeCode } from "../../src/utils/Types.sol";

--- a/test/utils/PasswordCaveatEnforcer.t.sol
+++ b/test/utils/PasswordCaveatEnforcer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { CaveatEnforcer } from "../../src/enforcers/CaveatEnforcer.sol";
 import { Execution, ModeCode } from "../../src/utils/Types.sol";

--- a/test/utils/SCLWrapperLib.sol
+++ b/test/utils/SCLWrapperLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { SCL_RIP7212 } from "@SCL/lib/libSCL_RIP7212.sol";
 

--- a/test/utils/SigningUtilsLib.t.sol
+++ b/test/utils/SigningUtilsLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Vm } from "forge-std/Vm.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";

--- a/test/utils/StorageUtilsLib.t.sol
+++ b/test/utils/StorageUtilsLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { Vm } from "forge-std/Vm.sol";
 import { BytesLib } from "@bytes-utils/BytesLib.sol";

--- a/test/utils/Types.t.sol
+++ b/test/utils/Types.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { DeleGatorCore } from "../../src/DeleGatorCore.sol";
 

--- a/test/utils/UserOperationLib.t.sol
+++ b/test/utils/UserOperationLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 


### PR DESCRIPTION
### **What?**
Set compiler version to be `^0.8.23` instead of `0.8.23`
Fixes #88 

-------------------------

### **Why?**
When importing the delegation framework into the Foundry project, having a locked compiler version is problematic. The project will not compile if it imports other third-party contracts that use a higher version of Solidity, such as `0.8.27`.

For instance, if a project imports both rhineston's module kit and the delegation framework, the project will not compile as most contracts in the module kit use `^0.8.27` and the delegation framework has locked compiler version `0.8.23`.  
Foundry does not support using multiple compiler versions in the same project.

-------------------------

### **How?**
Allowed using compiler versions `0.8.23` or higher.

