### PR TITLE
fix(enforcers): reject non-zero native value on ERC20 streaming and ownership transfer

### DIFF
--- a/src/enforcers/ERC20StreamingEnforcer.sol
+++ b/src/enforcers/ERC20StreamingEnforcer.sol
@@ -155,8 +155,9 @@ contract ERC20StreamingEnforcer is CaveatEnforcer {
     )
         private
     {
-        (address target_,, bytes calldata callData_) = _executionCallData.decodeSingle();
+        (address target_, uint256 value_, bytes calldata callData_) = _executionCallData.decodeSingle();
 
+        require(value_ == 0, "ERC20StreamingEnforcer:invalid-value");
         require(callData_.length == 68, "ERC20StreamingEnforcer:invalid-execution-length");
 
         (address token_, uint256 initialAmount_, uint256 maxAmount_, uint256 amountPerSecond_, uint256 startTime_) =

--- a/src/enforcers/OwnershipTransferEnforcer.sol
+++ b/src/enforcers/OwnershipTransferEnforcer.sol
@@ -72,8 +72,9 @@ contract OwnershipTransferEnforcer is CaveatEnforcer {
         pure
         returns (address newOwner_)
     {
-        (address target_,, bytes calldata callData_) = _executionCallData.decodeSingle();
+        (address target_, uint256 value_, bytes calldata callData_) = _executionCallData.decodeSingle();
 
+        require(value_ == 0, "OwnershipTransferEnforcer:invalid-value");
         require(callData_.length == 36, "OwnershipTransferEnforcer:invalid-execution-length");
 
         bytes4 selector_ = bytes4(callData_[0:4]);

--- a/test/enforcers/ERC20StreamingEnforcer.t.sol
+++ b/test/enforcers/ERC20StreamingEnforcer.t.sol
@@ -63,6 +63,17 @@ contract ERC20StreamingEnforcerTest is CaveatEnforcerBaseTest {
     }
 
     //////////////////// Error / Revert Tests //////////////////////
+
+    /// @notice Reverts if a streaming ERC20 transfer execution carries non-zero native value.
+    function test_revertOnNonZeroValue() public {
+        bytes memory terms_ = _encodeTerms(address(basicERC20), 10 ether, 100 ether, 1 ether, block.timestamp);
+        bytes memory callData_ = _encodeERC20Transfer(bob, 1 ether);
+        bytes memory execData_ = _encodeSingleExecution(address(basicERC20), 1, callData_);
+
+        vm.expectRevert(bytes("ERC20StreamingEnforcer:invalid-value"));
+        erc20StreamingEnforcer.beforeHook(terms_, bytes(""), singleDefaultMode, execData_, bytes32(0), address(0), alice);
+    }
+
     /**
      * @notice Ensures it reverts if `_terms.length != 148`.
      */

--- a/test/enforcers/OwnershipTransferEnforcer.t.sol
+++ b/test/enforcers/OwnershipTransferEnforcer.t.sol
@@ -63,6 +63,24 @@ contract OwnershipTransferEnforcerTest is CaveatEnforcerBaseTest {
 
     ////////////////////// Errors //////////////////////
 
+    // Reverts if ownership transfer execution carries non-zero native value
+    function test_revertOnNonZeroValue() public {
+        address newOwner = address(0x5678);
+        bytes memory terms_ = abi.encodePacked(mockContract);
+        transferOwnershipExecution = Execution({
+            target: mockContract,
+            value: 1,
+            callData: abi.encodeWithSelector(bytes4(keccak256("transferOwnership(address)")), newOwner)
+        });
+        transferOwnershipExecutionCallData = ExecutionLib.encodeSingle(
+            transferOwnershipExecution.target, transferOwnershipExecution.value, transferOwnershipExecution.callData
+        );
+
+        vm.prank(dm);
+        vm.expectRevert("OwnershipTransferEnforcer:invalid-value");
+        enforcer.beforeHook(terms_, hex"", singleDefaultMode, transferOwnershipExecutionCallData, bytes32(0), delegator, delegate);
+    }
+
     // Reverts if the terms length is invalid
     function test_invalid_termsLength() public {
         bytes memory invalidTerms = abi.encodePacked(mockContract, uint256(1)); // Too long


### PR DESCRIPTION
## Summary

Sibling of #195. Two more enforcers still decoded executions as `(target,, callData)` and never constrained native ETH:

- `ERC20StreamingEnforcer` (streaming ERC20 `transfer`)
- `OwnershipTransferEnforcer` (`transferOwnership`)

The framework executes `target.call{value: value}(callData)` from the delegator's account, so a token/ownership-scoped delegation placed no constraint on ETH riding along. For standard non-payable selectors this is inert today, but any payable `transfer` / `transferOwnership` target turns the delegation into an unbounded native spend.

The repo already requires `value == 0` in `ApprovalRevocationEnforcer` and `MultiTokenPeriodEnforcer` (ERC20 path), and #195 covers the other transfer enforcers. This PR brings the two remaining outliers into that pattern.

## Fix

Bind `value_` from `decodeSingle` and `require(value_ == 0, "...:invalid-value")` before the existing length/method checks.

## Test plan

- [x] `test_revertOnNonZeroValue` on both suites (execution `value = 1` expects `invalid-value`)
- [x] Mutation check: removing the streaming `require` makes `test_revertOnNonZeroValue` fail (`next call did not revert as expected`); restore passes
- [x] `forge test --match-contract 'ERC20StreamingEnforcerTest|OwnershipTransferEnforcerTest'` — 30/30 pass


Made with [Cursor](https://cursor.com)